### PR TITLE
fix(sprint1): resolve three correctness crashes and contract violations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,9 @@ This file tracks planned work across the project. Items are roughly ordered by p
 
 ### Sprint 1 — Correctness crashes and contract violations
 
-- [ ] **Fix `debugLogStackwright` temporal dead zone crash** — In `packages/core/src/utils/stackwrightComponentRegistry.ts`, the `debugLogStackwright` const arrow function is declared at line 82 but called starting at line 7. This is a `ReferenceError` at module load time if any `register()` call happens during initialization. Move the function declaration above the class.
-- [ ] **Fix cross-package source import in `PageLayout`** — `packages/core/src/components/structural/PageLayout.tsx:4` imports `SiteConfig` directly from `../../../../types/src/types/siteConfig` (the other package's `src/` directory). This breaks for downstream consumers who only have `dist/`. Change to `import { SiteConfig } from '@stackwright/types'`.
-- [ ] **Remove auto-registration side effect from `@stackwright/nextjs`** — `packages/nextjs/src/index.ts` calls `registerNextJSComponents()` as a module side effect, violating the documented contract ("Do not rely on module import side effects"). This causes double-registration when users also call it explicitly in `_app.tsx` as instructed. Remove the auto-call; explicit registration is sufficient.
+- [x] **Fix `debugLogStackwright` temporal dead zone crash** — In `packages/core/src/utils/stackwrightComponentRegistry.ts`, the `debugLogStackwright` const arrow function is declared at line 82 but called starting at line 7. This is a `ReferenceError` at module load time if any `register()` call happens during initialization. Move the function declaration above the class.
+- [x] **Fix cross-package source import in `PageLayout`** — `packages/core/src/components/structural/PageLayout.tsx:4` imports `SiteConfig` directly from `../../../../types/src/types/siteConfig` (the other package's `src/` directory). This breaks for downstream consumers who only have `dist/`. Change to `import { SiteConfig } from '@stackwright/types'`.
+- [x] **Remove auto-registration side effect from `@stackwright/nextjs`** — `packages/nextjs/src/index.ts` calls `registerNextJSComponents()` as a module side effect, violating the documented contract ("Do not rely on module import side effects"). This causes double-registration when users also call it explicitly in `_app.tsx` as instructed. Remove the auto-call; explicit registration is sufficient.
 
 ### Sprint 2 — Reliability and silent failure modes
 

--- a/packages/core/src/components/structural/PageLayout.tsx
+++ b/packages/core/src/components/structural/PageLayout.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mui/material";
 import TopAppBar from "./TopAppBar";
 import { PageContent } from "@stackwright/types";
-import { SiteConfig } from "../../../../types/src/types/siteConfig";
+import { SiteConfig } from "@stackwright/types";
 import BottomAppBar from "./BottomAppBar";
 import { renderContent } from "../../utils/contentRenderer";
 import { useSafeTheme } from "../../hooks/useSafeTheme";

--- a/packages/core/src/utils/stackwrightComponentRegistry.ts
+++ b/packages/core/src/utils/stackwrightComponentRegistry.ts
@@ -1,5 +1,12 @@
 import { StackwrightComponents, StackwrightComponentRegistry } from '../interfaces/stackwright-components';
 
+// Debug logging utility for stackwright registry
+const debugLogStackwright = (message: string, data?: any) => {
+  if (process.env.NODE_ENV === 'development' && process.env.STACKWRIGHT_DEBUG === 'true') {
+    console.log(`🚀 StackwrightRegistry Debug: ${message}`, data ? data : '');
+  }
+};
+
 class StackwrightComponentRegistryImpl implements StackwrightComponentRegistry {
   private components: Partial<StackwrightComponents> = {};
 
@@ -76,14 +83,6 @@ class StackwrightComponentRegistryImpl implements StackwrightComponentRegistry {
 
 // Singleton instance
 export const stackwrightRegistry = new StackwrightComponentRegistryImpl();
-
-
-// Debug logging utility for stackwright registry
-const debugLogStackwright = (message: string, data?: any) => {
-  if (process.env.NODE_ENV === 'development' && process.env.STACKWRIGHT_DEBUG === 'true') {
-    console.log(`🚀 StackwrightRegistry Debug: ${message}`, data ? data : '');
-  }
-};
 
 // Convenience functions for easier access
 export const getStackwrightImage = () => {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -25,6 +25,3 @@ export const nextJSStackwrightComponents = {
   Route: NextStackwrightRoute,
 };
 
-// Auto-register components when this module is imported
-registerNextJSComponents();
-console.log('🔧 Stackwright Next.js components registered');


### PR DESCRIPTION
- Move debugLogStackwright declaration above class in stackwrightComponentRegistry.ts to fix ReferenceError TDZ crash at module load time
- Replace cross-package src/ import in PageLayout.tsx with @stackwright/types to fix breakage for downstream consumers who only have dist/
- Remove auto-registration side effect from @stackwright/nextjs index.ts to prevent double-registration for users following documented explicit pattern