### PR TITLE
fix(ci): fix release workflow provenance failures and CI/CD correctness

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,46 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "packages/*/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/core"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/types"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/themes"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/icons"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/nextjs"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/cli"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/build-scripts"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/scripts/check-for-changeset.js
+++ b/.github/scripts/check-for-changeset.js
@@ -2,11 +2,11 @@ const { execSync } = require("child_process");
 const fs = require("fs");
 
 function getChangedFiles() {
-  const base = process.env.GITHUB_BASE_REF || "origin/dev";
+  const base = process.env.GITHUB_BASE_REF || "dev";
 
   try {
     // Ensure the base branch exists locally
-    execSync(`git fetch origin ${base}:${base}`, { stdio: "inherit" });
+    execSync(`git fetch origin ${base}`, { stdio: "inherit" });
 
     const diff = execSync(`git diff --name-only ${base}...HEAD`, {
       encoding: "utf-8",

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -56,6 +56,6 @@ jobs:
           git push origin dev
 
       - name: Publish prereleases with tag 'alpha'
-        run: pnpm changeset publish 
+        run: pnpm publish -r --provenance --access public --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,15 @@ jobs:
             - name: Upgrade npm for OIDC provenance support
               run: npm install -g npm@latest
 
+            - name: Configure git
+              run: |
+                  git config user.name "github-actions"
+                  git config user.email "github-actions@github.com"
+
             - name: Exit prerelease mode if active
               run: |
                   if [ -f ".changeset/pre.json" ]; then
                   pnpm changeset pre exit
-                  git config user.name "github-actions"
-                  git config user.email "github-actions@github.com"
                   git add .
                   git commit -m "chore: exit prerelease mode [skip ci]" || echo "No changes"
                   git push origin main
@@ -47,5 +50,13 @@ jobs:
             - name: Create versions and changelogs
               run: pnpm changeset version
 
+            - name: Commit version bumps
+              run: |
+                  git add .
+                  git diff --staged --quiet || git commit -m "chore: version packages [skip ci]"
+                  git push origin main
+
             - name: Publish to npm
               run: pnpm publish -r --provenance --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/build-scripts/package.json
+++ b/packages/build-scripts/package.json
@@ -2,6 +2,10 @@
     "name": "@stackwright/build-scripts",
     "version": "0.1.1",
     "description": "Build-time scripts for Stackwright projects (prebuild image processing, YAML compilation)",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Per-Aspera-LLC/stackwright"
+    },
     "main": "dist/index.js",
     "bin": {
         "stackwright-prebuild": "dist/prebuild.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,10 @@
   "name": "@stackwright/cli",
   "version": "0.4.0",
   "description": "CLI for Stackwright framework",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Per-Aspera-LLC/stackwright"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,10 @@
     "name": "@stackwright/core",
     "version": "0.4.1",
     "description": "Core framework for building applications from YAML configuration",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Per-Aspera-LLC/stackwright"
+    },
     "main": "./dist/index.js",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@stackwright/icons",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Per-Aspera-LLC/stackwright"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -2,6 +2,10 @@
     "name": "@stackwright/nextjs",
     "version": "0.2.3",
     "description": "Next.js implementations for Stackwright components",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Per-Aspera-LLC/stackwright"
+    },
     "main": "dist/index.js",
     "module": "dist/index.mjs",
     "types": "dist/index.d.ts",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@stackwright/themes",
   "version": "0.3.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Per-Aspera-LLC/stackwright"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,10 @@
     "name": "@stackwright/types",
     "version": "0.2.0",
     "description": "TypeScript types and JSON schemas for Stackwright",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Per-Aspera-LLC/stackwright"
+    },
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- **Root cause fix**: All 7 `packages/*/package.json` files were missing a `repository` field, causing npm to reject `--provenance` publishes with HTTP 422 (sigstore validates `repository.url` against the OIDC token)
- **`release.yml`**: Moved `git config` to a shared step; added a commit-and-push step after `pnpm changeset version` so version bumps and changelogs are persisted back to `main` (previously the changeset files were consumed but never committed, causing the same bump to re-apply on every push)
- **`prerelease.yml`**: Replaced `pnpm changeset publish` with `pnpm publish -r --provenance --access public --tag alpha` for consistency with release and to ensure provenance attestations on prereleases
- **`dependabot.yml`**: Replaced invalid `directory: "packages/*/"` glob (silently ignored by Dependabot) with explicit entries for all 7 packages + root + `github-actions` ecosystem
- **`check-for-changeset.js`**: Fixed `GITHUB_BASE_REF` fallback (`"origin/dev"` → `"dev"`) and fixed `git fetch origin ${base}:${base}` → `git fetch origin ${base}` (the original form fails when the local branch already exists)

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge to `main`, confirm the release workflow completes without E422
- [ ] Confirm version bump commit appears on `main` after release run
- [ ] Confirm Dependabot starts opening PRs for individual packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)