### PR TITLE
fix(core): clearContentTypeRegistry deregisters from componentRegistry

### DIFF
--- a/.changeset/fix-clear-content-type-registry.md
+++ b/.changeset/fix-clear-content-type-registry.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/core": patch
+---
+
+fix(core): clearContentTypeRegistry now also deregisters components from componentRegistry, eliminating the need for manual `delete componentRegistry[key]` workarounds in tests

--- a/packages/core/src/utils/componentRegistry.ts
+++ b/packages/core/src/utils/componentRegistry.ts
@@ -112,6 +112,11 @@ export function registerComponent(
     componentRegistry[contentType] = component;
 }
 
+// Helper to remove a component from the registry
+export function deregisterComponent(contentType: string): void {
+    delete componentRegistry[contentType];
+}
+
 // Re-export stackwright registry for convenience
 export {
     stackwrightRegistry,

--- a/packages/core/src/utils/contentTypeRegistry.ts
+++ b/packages/core/src/utils/contentTypeRegistry.ts
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react';
 import { z } from 'zod';
-import { registerComponent } from './componentRegistry';
+import { registerComponent, deregisterComponent } from './componentRegistry';
 
 export interface ContentTypeEntry {
   key: string;
@@ -56,5 +56,8 @@ export function getContentTypeSchema(key: string): z.ZodTypeAny | undefined {
 
 /** Clear all custom registrations. Intended for use in tests only. */
 export function clearContentTypeRegistry(): void {
+  for (const key of customContentTypes.keys()) {
+    deregisterComponent(key);
+  }
   customContentTypes.clear();
 }

--- a/packages/core/test/utils/contentTypeRegistry.test.ts
+++ b/packages/core/test/utils/contentTypeRegistry.test.ts
@@ -7,16 +7,13 @@ import {
     getContentTypeSchema,
     clearContentTypeRegistry,
 } from '../../src/utils/contentTypeRegistry';
-import { getComponentByType, componentRegistry } from '../../src/utils/componentRegistry';
+import { getComponentByType } from '../../src/utils/componentRegistry';
 
 const StubComponent = (() => null) as unknown as ComponentType<any>;
 const testSchema = z.object({ label: z.string(), text: z.string() });
 
 beforeEach(() => {
     clearContentTypeRegistry();
-    // Remove any custom types added to componentRegistry during tests
-    delete componentRegistry['test_widget'];
-    delete componentRegistry['another_widget'];
 });
 
 describe('registerContentType', () => {
@@ -45,8 +42,6 @@ describe('registerContentType', () => {
 
         expect(getContentTypeSchema('test_widget')).toBe(SchemaB);
         expect(getComponentByType('test_widget')).toBe(CompB);
-
-        delete componentRegistry['test_widget'];
     });
 });
 
@@ -66,8 +61,6 @@ describe('getRegisteredContentTypes', () => {
         expect(entries).toHaveLength(2);
         expect(entries.map(e => e.key)).toContain('test_widget');
         expect(entries.map(e => e.key)).toContain('another_widget');
-
-        delete componentRegistry['another_widget'];
     });
 
     it('each entry has key, schema, and component', () => {
@@ -85,5 +78,12 @@ describe('clearContentTypeRegistry', () => {
         clearContentTypeRegistry();
         expect(getRegisteredContentTypes()).toEqual([]);
         expect(getContentTypeSchema('test_widget')).toBeUndefined();
+    });
+
+    it('also deregisters components from componentRegistry', () => {
+        registerContentType('test_widget', testSchema, StubComponent);
+        expect(getComponentByType('test_widget')).toBe(StubComponent);
+        clearContentTypeRegistry();
+        expect(getComponentByType('test_widget')).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary

- Adds `deregisterComponent(key)` to `componentRegistry.ts`
- `clearContentTypeRegistry()` now iterates registered keys and calls `deregisterComponent` for each before clearing the map
- Removes the `delete componentRegistry[key]` workarounds from `contentTypeRegistry.test.ts` and adds a test that explicitly verifies `componentRegistry` is cleaned up

## Test plan

- [x] `pnpm test:core` — all 82 tests pass, including a new assertion for the deregistration behaviour
- [x] No manual `delete componentRegistry[...]` calls remain in `contentTypeRegistry.test.ts`

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)