### PR TITLE
refactor(cli): replace dynamic require() with static imports in types.ts

### DIFF
--- a/.changeset/refactor-cli-static-imports.md
+++ b/.changeset/refactor-cli-static-imports.md
@@ -1,0 +1,8 @@
+---
+"@stackwright/cli": patch
+---
+
+refactor(cli): replace dynamic require() with static imports for sub-type schema introspection
+
+Sub-type schemas are now imported statically from @stackwright/types, making the
+dependency explicit and eliminating the silent-drop risk when a schema is renamed.

--- a/packages/cli/src/commands/types.ts
+++ b/packages/cli/src/commands/types.ts
@@ -1,5 +1,14 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
+import {
+  textBlockSchema,
+  buttonContentSchema,
+  mediaItemSchema,
+  imageContentSchema,
+  iconContentSchema,
+  carouselItemSchema,
+  timelineItemSchema,
+} from '@stackwright/types';
 import { pageContentSchema } from '../utils/schema-loader';
 import { outputResult } from '../utils/json-output';
 
@@ -81,14 +90,14 @@ const CONTENT_TYPE_NAMES: Record<string, string> = {
   code_block: 'CodeBlockContent',
 };
 
-const SUB_TYPE_KEYS: Array<{ key: string; name: string }> = [
-  { key: 'textBlockSchema', name: 'TextBlock' },
-  { key: 'buttonContentSchema', name: 'ButtonContent' },
-  { key: 'mediaItemSchema', name: 'MediaItem' },
-  { key: 'imageContentSchema', name: 'ImageContent' },
-  { key: 'iconContentSchema', name: 'IconContent' },
-  { key: 'carouselItemSchema', name: 'CarouselItem' },
-  { key: 'timelineItemSchema', name: 'TimelineItem' },
+const SUB_TYPE_SCHEMAS: Array<{ name: string; schema: AnySchema }> = [
+  { name: 'TextBlock', schema: textBlockSchema as unknown as AnySchema },
+  { name: 'ButtonContent', schema: buttonContentSchema as unknown as AnySchema },
+  { name: 'MediaItem', schema: mediaItemSchema as unknown as AnySchema },
+  { name: 'ImageContent', schema: imageContentSchema as unknown as AnySchema },
+  { name: 'IconContent', schema: iconContentSchema as unknown as AnySchema },
+  { name: 'CarouselItem', schema: carouselItemSchema as unknown as AnySchema },
+  { name: 'TimelineItem', schema: timelineItemSchema as unknown as AnySchema },
 ];
 
 export function getTypes(): TypesResult {
@@ -117,15 +126,11 @@ export function getTypes(): TypesResult {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const types = require('@stackwright/types') as Record<string, unknown>;
-  const subTypes: ContentTypeEntry[] = SUB_TYPE_KEYS
-    .filter(({ key }) => types[key])
-    .map(({ key, name }) => ({
-      name,
-      typeName: name,
-      fields: extractFieldsFromSchema(types[key] as AnySchema),
-    }));
+  const subTypes: ContentTypeEntry[] = SUB_TYPE_SCHEMAS.map(({ name, schema }) => ({
+    name,
+    typeName: name,
+    fields: extractFieldsFromSchema(schema),
+  }));
 
   return { contentTypes, subTypes };
 }


### PR DESCRIPTION
## Summary

- Imports `textBlockSchema`, `buttonContentSchema`, `mediaItemSchema`, `imageContentSchema`, `iconContentSchema`, `carouselItemSchema`, and `timelineItemSchema` statically from `@stackwright/types`
- Replaces the string-keyed `SUB_TYPE_KEYS` array and `require('@stackwright/types')` call with `SUB_TYPE_SCHEMAS: Array<{ name, schema }>` holding direct schema references
- Removes the `eslint-disable @typescript-eslint/no-var-requires` comment and the `Record<string, unknown>` cast

## Test plan

- [x] `pnpm test` — all tests pass
- [x] `pnpm exec tsc --noEmit` in `packages/cli` — no new type errors in the changed file
- [x] A renamed schema now causes a compile error rather than silently disappearing from `pnpm stackwright -- types` output

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)