### PR TITLE
fix(types): resolve circular module init, restore buttonContentSchema.icon validation

### DIFF
--- a/.changeset/fix-button-icon-circular-dep.md
+++ b/.changeset/fix-button-icon-circular-dep.md
@@ -1,0 +1,10 @@
+---
+"@stackwright/types": patch
+---
+
+fix(types): restore full Zod validation for buttonContentSchema.icon
+
+Extracts a media-primitives.ts leaf module (no imports from base.ts) that
+defines a standalone mediaItemSchema, breaking the circular initialisation
+between base.ts and media.ts. buttonContentSchema.icon is now validated as
+a proper discriminated union instead of z.any().

--- a/packages/types/src/types/base.ts
+++ b/packages/types/src/types/base.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { typographyVariantSchema, buttonVariantSchema, alignmentVariantSchema } from './enums';
+import { mediaItemSchema } from './media-primitives';
 
 export const baseContentSchema = z.object({
     label: z.string(),
@@ -13,15 +14,12 @@ export const textBlockSchema = z.object({
     textColor: z.string().optional(),
 });
 
-// ButtonContent.icon is MediaItem, but media.ts imports baseContentSchema from this file.
-// To avoid a circular module init issue, icon is typed as z.any() at the Zod level.
-// TypeScript types remain correct via the explicit ButtonContent type below.
 export const buttonContentSchema = textBlockSchema.extend({
     variant: buttonVariantSchema,
     variantSize: z.enum(['small', 'medium', 'large']).optional(),
     href: z.string().optional(),
     action: z.string().optional(),
-    icon: z.any().optional(),
+    icon: mediaItemSchema.optional(),
     alignment: alignmentVariantSchema.optional(),
     bgColor: z.string().optional(),
 });

--- a/packages/types/src/types/media-primitives.ts
+++ b/packages/types/src/types/media-primitives.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+import { mediaStyleVariantSchema, typographyVariantSchema } from './enums';
+
+// Leaf module: no imports from base.ts.
+// Defines a self-contained mediaItemSchema used by buttonContentSchema in base.ts
+// to validate icon fields without creating a circular module initialisation:
+//   base.ts → media.ts → base.ts
+//
+// Fields from baseContentSchema (label, color, background) are inlined here as
+// optional, since embedded media items (e.g. button icons) do not require them.
+
+const mediaPrimitiveBaseSchema = z.object({
+    src: z.string(),
+    alt: z.string().optional(),
+    height: z.union([z.number(), z.string()]).optional(),
+    width: z.union([z.number(), z.string()]).optional(),
+    style: mediaStyleVariantSchema.optional(),
+    label: z.string().optional(),
+    color: z.string().optional(),
+    background: z.string().optional(),
+});
+
+const mediaContentPrimitiveSchema = mediaPrimitiveBaseSchema.extend({
+    type: z.literal('media'),
+});
+
+const iconContentPrimitiveSchema = mediaPrimitiveBaseSchema.extend({
+    type: z.literal('icon'),
+    size: z.union([z.number(), typographyVariantSchema]).optional(),
+    color: z.string().optional(),
+});
+
+const imageContentPrimitiveSchema = mediaPrimitiveBaseSchema.extend({
+    type: z.literal('image'),
+    aspect_ratio: z.number().optional(),
+});
+
+export const mediaItemSchema = z.discriminatedUnion('type', [
+    mediaContentPrimitiveSchema,
+    iconContentPrimitiveSchema,
+    imageContentPrimitiveSchema,
+]);
+
+export type MediaItem = z.infer<typeof mediaItemSchema>;

--- a/packages/types/src/types/media.ts
+++ b/packages/types/src/types/media.ts
@@ -25,13 +25,12 @@ export const imageContentSchema = mediaBaseSchema.extend({
     aspect_ratio: z.number().optional(),
 });
 
-export const mediaItemSchema = z.discriminatedUnion('type', [
-    mediaContentSchema,
-    iconContentSchema,
-    imageContentSchema,
-]);
-
 export type MediaContent = z.infer<typeof mediaContentSchema>;
 export type IconContent = z.infer<typeof iconContentSchema>;
 export type ImageContent = z.infer<typeof imageContentSchema>;
-export type MediaItem = z.infer<typeof mediaItemSchema>;
+
+// mediaItemSchema and MediaItem are defined in media-primitives.ts (a leaf module
+// with no imports from base.ts) so that base.ts can import them for
+// buttonContentSchema.icon without creating a circular module dependency.
+export { mediaItemSchema } from './media-primitives';
+export type { MediaItem } from './media-primitives';


### PR DESCRIPTION
## Summary

- Creates `packages/types/src/types/media-primitives.ts` — a leaf module with no imports from `base.ts` — that defines a standalone `mediaItemSchema` (discriminated union of `media | icon | image`)
- `base.ts` imports `mediaItemSchema` from `media-primitives.ts` for `buttonContentSchema.icon`, replacing the `z.any()` escape hatch
- `media.ts` re-exports `mediaItemSchema` and `MediaItem` from `media-primitives.ts` for backward compatibility; its own `mediaContentSchema` / `iconContentSchema` / `imageContentSchema` (which extend `baseContentSchema`) are unchanged
- JSON schemas regenerated via `pnpm generate-schemas`

## Dependency graph after this change

```
enums.ts ←─── media-primitives.ts ←─── base.ts
                                          ↓
enums.ts ←────── media.ts (re-exports mediaItemSchema from media-primitives.ts)
base.ts  ←────── media.ts
```

No cycle.

## Test plan

- [x] `pnpm exec tsc --noEmit` in `packages/types` — clean
- [x] `pnpm test` — all tests pass
- [x] `pnpm generate-schemas` — schemas regenerated successfully

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)