### PR TITLE
fix(ci): fix release workflow install order and prerelease re-entry loop

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,7 +29,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Ensure Changeset prerelease mode is entered
         run: |
-            if [ ! -f ".changeset/pre.json" ]; then
+            PENDING=$(ls .changeset/*.md 2>/dev/null | wc -l)
+            if [ ! -f ".changeset/pre.json" ] && [ "$PENDING" -gt 0 ]; then
             pnpm changeset pre enter alpha
             git config user.name "github-actions"
             git config user.email "github-actions@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
                   git config user.name "github-actions"
                   git config user.email "github-actions@github.com"
 
+            - run: pnpm install --frozen-lockfile
+
             - name: Exit prerelease mode if active
               run: |
                   if [ -f ".changeset/pre.json" ]; then
@@ -43,8 +45,6 @@ jobs:
                   git commit -m "chore: exit prerelease mode [skip ci]" || echo "No changes"
                   git push origin main
                   fi
-
-            - run: pnpm install --frozen-lockfile
             - run: pnpm build
 
             - name: Create versions and changelogs


### PR DESCRIPTION
## Summary

Two CI bugs found while troubleshooting the failed Release workflow run (#22510774745).

### Root cause 1 — Release workflow: `pnpm install` ran after `changeset pre exit`

The "Exit prerelease mode if active" step called `pnpm changeset pre exit` before `node_modules` existed, so the `changeset` binary couldn't be found:

```
sh: 1: changeset: not found
WARN  Local package.json exists, but node_modules missing, did you mean to install?
```

**Fix:** Move `pnpm install --frozen-lockfile` to before the prerelease exit step.

### Root cause 2 — Prerelease Dev workflow: unconditional prerelease re-entry

When our exit-prerelease commit (`ce7264e`) landed on dev, the Prerelease Dev workflow saw no `pre.json` and immediately re-entered prerelease mode (`c0715b9 chore: enter prerelease mode`). That commit got swept into PR #71 and onto main, giving main a fresh `pre.json` with empty changesets — which in turn triggered root cause 1.

**Fix:** Only enter prerelease mode if there are pending changeset `.md` files. No changesets + no `pre.json` means we just released; don't re-enter.

```bash
PENDING=$(ls .changeset/*.md 2>/dev/null | wc -l)
if [ ! -f ".changeset/pre.json" ] && [ "$PENDING" -gt 0 ]; then
  pnpm changeset pre enter alpha
  ...
fi
```

## Test plan

- [ ] Merge this PR → Release workflow runs with fixed install order → exits prerelease on main → publishes stable packages
- [ ] Subsequent changeset on dev → Prerelease Dev only re-enters prerelease when there are actual pending changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)