### PR TITLE
fix(packaging): add missing files field to icons, themes, cli packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/Per-Aspera-LLC/stackwright"
   },
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/Per-Aspera-LLC/stackwright"
   },
+  "files": [
+    "dist"
+  ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/Per-Aspera-LLC/stackwright"
   },
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Without a "files" field, npm includes src/, tsconfig.json, tsup.config.ts, vitest.config.ts, and other dev artifacts in the published tarball. All other packages (core, types, nextjs, build-scripts, mcp) already had "files": ["dist"] set correctly.