### PR TITLE
feat(cli): auto-generate AGENTS.md content type tables from Zod schemas

### DIFF
--- a/.changeset/auto-generate-agent-docs.md
+++ b/.changeset/auto-generate-agent-docs.md
@@ -1,0 +1,12 @@
+---
+"@stackwright/cli": minor
+---
+
+feat(cli): add `generate-agent-docs` command to auto-generate AGENTS.md content type reference tables from live Zod schemas (closes #83)
+
+- New `pnpm stackwright -- generate-agent-docs` command introspects Zod schemas at runtime and regenerates the content type reference tables in `/AGENTS.md` and `examples/hellostackwrightnext/AGENTS.md`
+- Tables are delimited by `<!-- stackwright:content-type-table:start/end -->` HTML comment markers; non-table content is preserved
+- Schema name registry maps Zod schema object references to human-readable type names (TextBlock, MediaItem, etc.) for readable output
+- Fixed `resolveSchema` to correctly handle `optional(lazy(...))` wrapper nesting (fixes `tabbed_content` showing empty fields)
+- CI job `check-agent-docs` runs the generator and fails with an actionable message if AGENTS.md is out of sync
+- `generateAgentDocs()` exported from `@stackwright/cli` for programmatic use

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,26 @@ jobs:
       - name: Build scaffold output
         run: pnpm build
         working-directory: /tmp/test-site
+
+  check-agent-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install
+      - run: pnpm build
+
+      - name: Regenerate AGENTS.md tables
+        run: node packages/cli/dist/cli.js generate-agent-docs
+
+      - name: Fail if AGENTS.md is out of sync with schemas
+        run: |
+          git diff --exit-code AGENTS.md examples/hellostackwrightnext/AGENTS.md || \
+          (echo "AGENTS.md is out of sync. Run 'pnpm stackwright -- generate-agent-docs' and commit the result." && exit 1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,34 +49,35 @@ Without these hooks, co-located images will not be found at runtime.
 
 ### Content Type Reference
 
-**AGENTS: This table is the source of truth for valid YAML content types. If you add, remove, or change fields in `packages/types/src/types/`, you MUST update this table and the matching table in `examples/hellostackwrightnext/AGENTS.md`.**
+**AGENTS: This table is auto-generated from the live Zod schemas. Run `pnpm stackwright -- generate-agent-docs` to regenerate. Do NOT edit the content between the markers manually.**
 
+<!-- stackwright:content-type-table:start -->
 The YAML key is the key used inside `content_items` entries. All types inherit `label` (required), `color` (optional), and `background` (optional) from `BaseContent`.
 
 | YAML key | Required fields | Optional fields |
 |---|---|---|
-| `main` | `label`, `heading` (TextBlock), `textBlocks` (TextBlock[]) | `media` (MediaItem), `graphic_position` (`left`\|`right`), `buttons` (ButtonContent[]), `textToGraphic` (0-100, default 58), `background` |
-| `carousel` | `label`, `heading` (string), `items` (CarouselItem[]) | `autoPlay` (bool), `autoPlaySpeed` (ms), `infinite` (bool), `background` |
-| `timeline` | `label`, `items` (TimelineItem[]) | `heading` (TextBlock) |
-| `icon_grid` | `label`, `icons` (IconContent[]) | `heading` (TextBlock) |
-| `tabbed_content` | `label`, `heading` (TextBlock), `tabs` (ContentItem[]) | — |
-| `media` | `label`, `type: "media"`, `src` (string) | `alt`, `height`, `width`, `style` (`contained`\|`overflow`) |
-| `code_block` | `label`, `code` (string) | `language` (string), `lineNumbers` (bool, default false), `background` |
+| `carousel` | `label` (string), `heading` (string), `items` (CarouselItem[]) | `color` (string), `background` (string), `autoPlaySpeed` (number), `infinite` (boolean), `autoPlay` (boolean) |
+| `main` | `label` (string), `heading` (TextBlock), `textBlocks` (TextBlock[]) | `color` (string), `background` (string), `media` (MediaItem), `graphic_position` (`left` | `right`), `buttons` (ButtonContent[]), `textToGraphic` (number) |
+| `tabbed_content` | `label` (string), `heading` (TextBlock), `tabs` (object[]) | `color` (string), `background` (string) |
+| `media` | `label` (string), `src` (string), `type` ("media") | `color` (string), `background` (string), `alt` (string), `height` (number | string), `width` (number | string), `style` (`contained` | `overflow`) |
+| `timeline` | `label` (string), `items` (TimelineItem[]) | `color` (string), `background` (string), `heading` (TextBlock) |
+| `icon_grid` | `label` (string), `icons` (IconContent[]) | `color` (string), `background` (string), `heading` (TextBlock) |
+| `code_block` | `label` (string), `code` (string) | `color` (string), `background` (string), `language` (string), `lineNumbers` (boolean) |
 
 **Sub-type reference:**
 
 | Type | Fields |
 |---|---|
 | `TextBlock` | `text` (string), `textSize` (TypographyVariant), `textColor`? (string) |
-| `ButtonContent` | `text`, `textSize`, `variant` (`text`\|`outlined`\|`contained`), `href`?, `bgColor`?, `textColor`?, `variantSize`? (`small`\|`medium`\|`large`), `icon`? (MediaItem), `alignment`? (`left`\|`center`\|`right`) |
-| `MediaContent` | `type: "media"` (required), `label` (string), `src` (file path or URL), `alt`?, `height`?, `width`?, `style`? (`contained`\|`overflow`) |
-| `ImageContent` | `type: "image"` (required), `label` (string), `src` (file path or URL), `alt`?, `height`?, `width`?, `aspect_ratio`? (number), `style`? (`contained`\|`overflow`) |
-| `IconContent` | `type: "icon"` (required), `label` (string), `src` (registry key — see `@stackwright/icons` AGENTS.md for valid names), `color`?, `height`? (px, default 24), `size`? (number \| TypographyVariant) |
-| `MediaItem` | Union of `MediaContent` \| `ImageContent` \| `IconContent`. `type` is required on all three and acts as the discriminator. |
-| `CarouselItem` | `title` (string), `text` (string), `media` (MediaItem), `background`? |
+| `ButtonContent` | `text` (string), `textSize` (TypographyVariant), `textColor`? (string), `variant` (`text` | `outlined` | `contained`), `variantSize`? (`small` | `medium` | `large`), `href`? (string), `action`? (string), `icon`? (MediaItem), `alignment`? (`left` | `center` | `right`), `bgColor`? (string) |
+| `MediaItem` | Discriminated union: `type: "media"` \| `type: "icon"` \| `type: "image"`. `type` field is required and acts as discriminator. |
+| `ImageContent` | `label` (string), `color`? (string), `background`? (string), `src` (string), `alt`? (string), `height`? (number | string), `width`? (number | string), `style`? (`contained` | `overflow`), `type` ("image"), `aspect_ratio`? (number) |
+| `IconContent` | `label` (string), `color`? (string), `background`? (string), `src` (string), `alt`? (string), `height`? (number | string), `width`? (number | string), `style`? (`contained` | `overflow`), `type` ("icon"), `size`? (number | TypographyVariant) |
+| `CarouselItem` | `title` (string), `text` (string), `media` (MediaItem), `background`? (string) |
 | `TimelineItem` | `year` (string), `event` (string) |
 
 **TypographyVariant values:** `h1` `h2` `h3` `h4` `h5` `h6` `subtitle1` `subtitle2` `body1` `body2` `caption` `button` `overline`
+<!-- stackwright:content-type-table:end -->
 
 ### Integration Points and Cross-Component Communication
 - **Service Boundaries**: No obvious service boundaries, all code resides within the project's monorepo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,11 +109,10 @@ User's Next.js App
 ### Content Type Maintenance Rule
 
 **When modifying `packages/types/src/types/` — adding, removing, or changing any content type, field, or enum — you MUST:**
-1. Update the Content Type Reference table in `/AGENTS.md`
-2. Update the matching table in `examples/hellostackwrightnext/AGENTS.md`
-3. Regenerate JSON schemas: `cd packages/types && pnpm generate-schemas`
+1. Run `pnpm stackwright -- generate-agent-docs` to regenerate AGENTS.md tables in both `/AGENTS.md` and `examples/hellostackwrightnext/AGENTS.md`
+2. Regenerate JSON schemas: `cd packages/types && pnpm generate-schemas`
 
-The AGENTS.md tables are the primary reference for agents writing YAML content. Stale tables will cause agents to write invalid YAML.
+The AGENTS.md tables are auto-generated from the live Zod schemas. Do NOT edit the content between the `<!-- stackwright:content-type-table:start/end -->` markers manually — run `generate-agent-docs` instead. CI will fail if the tables are out of sync.
 
 ### Naming Conventions
 

--- a/examples/hellostackwrightnext/AGENTS.md
+++ b/examples/hellostackwrightnext/AGENTS.md
@@ -116,34 +116,35 @@ rm -rf .next && pnpm build
 
 ### YAML Key Reference
 
-**AGENTS: This table must stay in sync with `packages/types/src/types/` in the monorepo root. If you add, remove, or change any content type fields, update this table AND the matching table in the root `AGENTS.md`.**
+**AGENTS: This table is auto-generated from the live Zod schemas. Run `pnpm stackwright -- generate-agent-docs` from the monorepo root to regenerate. Do NOT edit the content between the markers manually.**
 
+<!-- stackwright:content-type-table:start -->
 The YAML key is the key used inside `content_items` entries. All types inherit `label` (required), `color` (optional), and `background` (optional) from `BaseContent`.
 
 | YAML key | Required fields | Optional fields |
 |---|---|---|
-| `main` | `label`, `heading` (TextBlock), `textBlocks` (TextBlock[]) | `media` (MediaItem), `graphic_position` (`left`\|`right`), `buttons` (ButtonContent[]), `textToGraphic` (0-100, default 58), `background` |
-| `carousel` | `label`, `heading` (string), `items` (CarouselItem[]) | `autoPlay` (bool), `autoPlaySpeed` (ms), `infinite` (bool), `background` |
-| `timeline` | `label`, `items` (TimelineItem[]) | `heading` (TextBlock) |
-| `icon_grid` | `label`, `icons` (IconContent[]) | `heading` (TextBlock) |
-| `tabbed_content` | `label`, `heading` (TextBlock), `tabs` (ContentItem[]) | — |
-| `media` | `label`, `type: "media"`, `src` (string) | `alt`, `height`, `width`, `style` (`contained`\|`overflow`) |
-| `code_block` | `label`, `code` (string) | `language` (string), `lineNumbers` (bool, default false), `background` |
+| `carousel` | `label` (string), `heading` (string), `items` (CarouselItem[]) | `color` (string), `background` (string), `autoPlaySpeed` (number), `infinite` (boolean), `autoPlay` (boolean) |
+| `main` | `label` (string), `heading` (TextBlock), `textBlocks` (TextBlock[]) | `color` (string), `background` (string), `media` (MediaItem), `graphic_position` (`left` | `right`), `buttons` (ButtonContent[]), `textToGraphic` (number) |
+| `tabbed_content` | `label` (string), `heading` (TextBlock), `tabs` (object[]) | `color` (string), `background` (string) |
+| `media` | `label` (string), `src` (string), `type` ("media") | `color` (string), `background` (string), `alt` (string), `height` (number | string), `width` (number | string), `style` (`contained` | `overflow`) |
+| `timeline` | `label` (string), `items` (TimelineItem[]) | `color` (string), `background` (string), `heading` (TextBlock) |
+| `icon_grid` | `label` (string), `icons` (IconContent[]) | `color` (string), `background` (string), `heading` (TextBlock) |
+| `code_block` | `label` (string), `code` (string) | `color` (string), `background` (string), `language` (string), `lineNumbers` (boolean) |
 
 **Sub-type reference:**
 
 | Type | Fields |
 |---|---|
 | `TextBlock` | `text` (string), `textSize` (TypographyVariant), `textColor`? (string) |
-| `ButtonContent` | `text`, `textSize`, `variant` (`text`\|`outlined`\|`contained`), `href`?, `bgColor`?, `textColor`?, `variantSize`? (`small`\|`medium`\|`large`), `icon`? (MediaItem), `alignment`? (`left`\|`center`\|`right`) |
-| `MediaContent` | `type: "media"` (required), `label` (string), `src` (file path or URL), `alt`?, `height`?, `width`?, `style`? (`contained`\|`overflow`) |
-| `ImageContent` | `type: "image"` (required), `label` (string), `src` (file path or URL), `alt`?, `height`?, `width`?, `aspect_ratio`? (number), `style`? (`contained`\|`overflow`) |
-| `IconContent` | `type: "icon"` (required), `label` (string), `src` (registry key — see `@stackwright/icons` AGENTS.md for valid names), `color`?, `height`? (px, default 24), `size`? (number \| TypographyVariant) |
-| `MediaItem` | Union of `MediaContent` \| `ImageContent` \| `IconContent`. `type` is required on all three and acts as the discriminator. |
-| `CarouselItem` | `title` (string), `text` (string), `media` (MediaItem), `background`? |
+| `ButtonContent` | `text` (string), `textSize` (TypographyVariant), `textColor`? (string), `variant` (`text` | `outlined` | `contained`), `variantSize`? (`small` | `medium` | `large`), `href`? (string), `action`? (string), `icon`? (MediaItem), `alignment`? (`left` | `center` | `right`), `bgColor`? (string) |
+| `MediaItem` | Discriminated union: `type: "media"` \| `type: "icon"` \| `type: "image"`. `type` field is required and acts as discriminator. |
+| `ImageContent` | `label` (string), `color`? (string), `background`? (string), `src` (string), `alt`? (string), `height`? (number | string), `width`? (number | string), `style`? (`contained` | `overflow`), `type` ("image"), `aspect_ratio`? (number) |
+| `IconContent` | `label` (string), `color`? (string), `background`? (string), `src` (string), `alt`? (string), `height`? (number | string), `width`? (number | string), `style`? (`contained` | `overflow`), `type` ("icon"), `size`? (number | TypographyVariant) |
+| `CarouselItem` | `title` (string), `text` (string), `media` (MediaItem), `background`? (string) |
 | `TimelineItem` | `year` (string), `event` (string) |
 
 **TypographyVariant values:** `h1` `h2` `h3` `h4` `h5` `h6` `subtitle1` `subtitle2` `body1` `body2` `caption` `button` `overline`
+<!-- stackwright:content-type-table:end -->
 
 ### YAML Examples
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,7 @@ import { registerTypes } from './commands/types';
 import { registerPrebuild } from './commands/prebuild';
 import { registerTheme } from './commands/theme';
 import { registerInfo } from './commands/info';
+import { registerGenerateAgentDocs } from './commands/generate-agent-docs';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require('../package.json') as { version: string };
@@ -29,6 +30,7 @@ async function main(): Promise<void> {
   registerPrebuild(program);
   registerTheme(program);
   registerInfo(program);
+  registerGenerateAgentDocs(program);
 
   // Pre-parse to extract global options (including --plugin-dir) before full dispatch.
   // parseOptions() does NOT dispatch commands — it only extracts options.

--- a/packages/cli/src/commands/generate-agent-docs.ts
+++ b/packages/cli/src/commands/generate-agent-docs.ts
@@ -1,0 +1,329 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Command } from 'commander';
+import {
+  textBlockSchema,
+  buttonContentSchema,
+  mediaItemSchema,
+  imageContentSchema,
+  iconContentSchema,
+  carouselItemSchema,
+  timelineItemSchema,
+  typographyVariantSchema,
+} from '@stackwright/types';
+import { pageContentSchema } from '../utils/schema-loader';
+import { outputResult } from '../utils/json-output';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDef = Record<string, any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySchema = { def: AnyDef };
+
+export interface GenerateAgentDocsResult {
+  filesUpdated: string[];
+  filesSkipped: string[];
+  errors: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Markers — delimit the auto-generated section in each AGENTS.md file
+// ---------------------------------------------------------------------------
+
+const START_MARKER = '<!-- stackwright:content-type-table:start -->';
+const END_MARKER = '<!-- stackwright:content-type-table:end -->';
+
+// ---------------------------------------------------------------------------
+// Schema name registry — maps Zod schema object references to display names.
+// When zodSchemaToTypeString encounters one of these schemas (after resolving
+// optional/lazy wrappers), it returns the human-readable name instead of
+// the raw Zod type string (e.g. "object", "object | object | object").
+// ---------------------------------------------------------------------------
+
+const SCHEMA_NAMES = new Map<object, string>([
+  [textBlockSchema as object, 'TextBlock'],
+  [buttonContentSchema as object, 'ButtonContent'],
+  [mediaItemSchema as object, 'MediaItem'],
+  [imageContentSchema as object, 'ImageContent'],
+  [iconContentSchema as object, 'IconContent'],
+  [carouselItemSchema as object, 'CarouselItem'],
+  [timelineItemSchema as object, 'TimelineItem'],
+  [typographyVariantSchema as object, 'TypographyVariant'],
+]);
+
+// ---------------------------------------------------------------------------
+// Zod v4 runtime schema introspection helpers
+// ---------------------------------------------------------------------------
+
+function resolveSchema(schema: AnySchema): AnySchema {
+  let s = schema;
+  // Run combined loop to handle nested wrappers like optional(lazy(...))
+  let changed = true;
+  while (changed) {
+    changed = false;
+    if (s.def.type === 'lazy')     { s = s.def.getter() as AnySchema;   changed = true; }
+    if (s.def.type === 'optional') { s = s.def.innerType as AnySchema; changed = true; }
+  }
+  return s;
+}
+
+function zodSchemaToTypeString(schema: AnySchema): string {
+  // Check direct reference against name registry (before and after resolving)
+  if (SCHEMA_NAMES.has(schema as object)) return SCHEMA_NAMES.get(schema as object)!;
+  const resolved = resolveSchema(schema);
+  if (SCHEMA_NAMES.has(resolved as object)) return SCHEMA_NAMES.get(resolved as object)!;
+
+  const def = resolved.def;
+  switch (def.type) {
+    case 'string':   return 'string';
+    case 'number':   return 'number';
+    case 'boolean':  return 'boolean';
+    case 'optional': return zodSchemaToTypeString(def.innerType as AnySchema);
+    case 'lazy':     return zodSchemaToTypeString(def.getter() as AnySchema);
+    case 'enum': {
+      const values: string[] = def.entries ? Object.keys(def.entries) : [];
+      return values.map((v) => `\`${v}\``).join(' | ');
+    }
+    case 'literal': {
+      const val = def.values ? (def.values as unknown[])[0] : def.value;
+      return `"${String(val)}"`;
+    }
+    case 'array':
+      return `${zodSchemaToTypeString(def.element as AnySchema)}[]`;
+    case 'union':
+    case 'discriminated_union': {
+      const members = (def.options as AnySchema[]).map((o) => {
+        const r = resolveSchema(o);
+        if (SCHEMA_NAMES.has(r as object)) return SCHEMA_NAMES.get(r as object)!;
+        // Recurse so primitives (number, string, etc.) resolve correctly
+        return zodSchemaToTypeString(r);
+      });
+      return members.join(' | ');
+    }
+    case 'object': return 'object';
+    default:       return def.type ?? 'unknown';
+  }
+}
+
+interface FieldInfo {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+function extractFields(schema: AnySchema): FieldInfo[] {
+  const resolved = resolveSchema(schema);
+  if (resolved.def.type !== 'object') return [];
+  const shape = resolved.def.shape as Record<string, AnySchema>;
+  return Object.entries(shape).map(([name, fieldSchema]) => ({
+    name,
+    type: zodSchemaToTypeString(fieldSchema),
+    required: fieldSchema.def.type !== 'optional',
+  }));
+}
+
+function fmtField(field: FieldInfo, showOptMark = false): string {
+  const namePart = showOptMark && !field.required
+    ? `\`${field.name}\`?`
+    : `\`${field.name}\``;
+  return `${namePart} (${field.type})`;
+}
+
+// ---------------------------------------------------------------------------
+// Table generators
+// ---------------------------------------------------------------------------
+
+function generateContentTypeTable(): string {
+  const root = resolveSchema(pageContentSchema as unknown as AnySchema);
+  if (root.def.type !== 'object') return '';
+
+  const contentField = (root.def.shape as Record<string, AnySchema>).content;
+  const contentResolved = resolveSchema(contentField);
+  if (contentResolved.def.type !== 'object') return '';
+
+  const contentItemsField = (contentResolved.def.shape as Record<string, AnySchema>).content_items;
+  let itemSchema: AnySchema | null = null;
+  if (contentItemsField.def.type === 'array') {
+    itemSchema = resolveSchema(contentItemsField.def.element as AnySchema);
+  }
+  if (!itemSchema || itemSchema.def.type !== 'object') return '';
+
+  const lines = [
+    '| YAML key | Required fields | Optional fields |',
+    '|---|---|---|',
+  ];
+
+  const shape = itemSchema.def.shape as Record<string, AnySchema>;
+  for (const [yamlKey, fieldSchema] of Object.entries(shape)) {
+    const fields = extractFields(fieldSchema);
+    const required = fields.filter((f) => f.required).map((f) => fmtField(f)).join(', ');
+    const optional = fields.filter((f) => !f.required).map((f) => fmtField(f)).join(', ');
+    lines.push(`| \`${yamlKey}\` | ${required} | ${optional || '—'} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function generateSubTypeTable(): string {
+  const subTypes: Array<{ name: string; schema: AnySchema }> = [
+    { name: 'TextBlock',     schema: textBlockSchema as unknown as AnySchema },
+    { name: 'ButtonContent', schema: buttonContentSchema as unknown as AnySchema },
+    { name: 'MediaItem',     schema: mediaItemSchema as unknown as AnySchema },
+    { name: 'ImageContent',  schema: imageContentSchema as unknown as AnySchema },
+    { name: 'IconContent',   schema: iconContentSchema as unknown as AnySchema },
+    { name: 'CarouselItem',  schema: carouselItemSchema as unknown as AnySchema },
+    { name: 'TimelineItem',  schema: timelineItemSchema as unknown as AnySchema },
+  ];
+
+  const lines = [
+    '| Type | Fields |',
+    '|---|---|',
+  ];
+
+  for (const { name, schema } of subTypes) {
+    const resolved = resolveSchema(schema);
+    const isUnion = resolved.def.type === 'discriminated_union' || resolved.def.type === 'union';
+    if (isUnion && resolved.def.options) {
+      // e.g. MediaItem — show discriminator values from each member's `type` literal field
+      const members = (resolved.def.options as AnySchema[]).map((o) => {
+        const r = resolveSchema(o);
+        if (SCHEMA_NAMES.has(r as object)) return `\`${SCHEMA_NAMES.get(r as object)!}\``;
+        const typeField = (r.def.shape as Record<string, AnySchema> | undefined)?.type;
+        if (typeField) {
+          const tf = resolveSchema(typeField);
+          if (tf.def.type === 'literal') {
+            const v = tf.def.values ? (tf.def.values as unknown[])[0] : tf.def.value;
+            return `\`type: "${String(v)}"\``;
+          }
+        }
+        return 'object';
+      });
+      lines.push(`| \`${name}\` | Discriminated union: ${members.join(' \\| ')}. \`type\` field is required and acts as discriminator. |`);
+    } else {
+      const fields = extractFields(schema);
+      const fieldList = fields.map((f) => fmtField(f, true)).join(', ');
+      lines.push(`| \`${name}\` | ${fieldList} |`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function generateTypographyLine(): string {
+  const def = (typographyVariantSchema as unknown as AnySchema).def;
+  const values: string[] = def.entries ? Object.keys(def.entries) : [];
+  return `**TypographyVariant values:** ${values.map((v) => `\`${v}\``).join(' ')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Build the full generated block (content between the markers)
+// ---------------------------------------------------------------------------
+
+function buildGeneratedBlock(): string {
+  const contentTable = generateContentTypeTable();
+  const subTypeTable = generateSubTypeTable();
+  const typographyLine = generateTypographyLine();
+
+  return [
+    'The YAML key is the key used inside `content_items` entries. All types inherit `label` (required), `color` (optional), and `background` (optional) from `BaseContent`.',
+    '',
+    contentTable,
+    '',
+    '**Sub-type reference:**',
+    '',
+    subTypeTable,
+    '',
+    typographyLine,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// File update logic
+// ---------------------------------------------------------------------------
+
+function updateAgentsMd(filePath: string, newBlock: string): 'updated' | 'up-to-date' | 'no-markers' | 'not-found' {
+  if (!fs.existsSync(filePath)) return 'not-found';
+
+  const current = fs.readFileSync(filePath, 'utf-8');
+  const startIdx = current.indexOf(START_MARKER);
+  const endIdx = current.indexOf(END_MARKER);
+
+  if (startIdx === -1 || endIdx === -1) return 'no-markers';
+
+  const before = current.slice(0, startIdx + START_MARKER.length);
+  const after = current.slice(endIdx);
+  const updated = `${before}\n${newBlock}\n${after}`;
+
+  if (updated === current) return 'up-to-date';
+
+  fs.writeFileSync(filePath, updated, 'utf-8');
+  return 'updated';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function generateAgentDocs(root: string = process.cwd()): GenerateAgentDocsResult {
+  const newBlock = buildGeneratedBlock();
+
+  const targetFiles = [
+    path.join(root, 'AGENTS.md'),
+    path.join(root, 'examples', 'hellostackwrightnext', 'AGENTS.md'),
+  ];
+
+  const filesUpdated: string[] = [];
+  const filesSkipped: string[] = [];
+  const errors: string[] = [];
+
+  for (const filePath of targetFiles) {
+    const result = updateAgentsMd(filePath, newBlock);
+    switch (result) {
+      case 'updated':    filesUpdated.push(filePath); break;
+      case 'up-to-date': filesSkipped.push(filePath); break;
+      case 'no-markers': errors.push(`Markers not found in: ${filePath}`); break;
+      case 'not-found':  errors.push(`File not found: ${filePath}`); break;
+    }
+  }
+
+  return { filesUpdated, filesSkipped, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Commander registration
+// ---------------------------------------------------------------------------
+
+export function registerGenerateAgentDocs(program: Command): void {
+  program
+    .command('generate-agent-docs')
+    .description('Regenerate AGENTS.md content type reference tables from live Zod schemas')
+    .option('--root <path>', 'Root directory of the monorepo (defaults to cwd)')
+    .option('--json', 'Output machine-readable JSON')
+    .action((opts: { root?: string; json?: boolean }) => {
+      const root = opts.root ?? process.cwd();
+      const result = generateAgentDocs(root);
+
+      outputResult(result, { json: Boolean(opts.json) }, () => {
+        if (result.errors.length > 0) {
+          for (const err of result.errors) {
+            process.stderr.write(`Error: ${err}\n`);
+          }
+          process.exit(1);
+        }
+
+        if (result.filesUpdated.length === 0 && result.filesSkipped.length > 0) {
+          console.log('AGENTS.md files are already up to date.');
+        } else {
+          for (const f of result.filesUpdated) {
+            console.log(`Updated: ${f}`);
+          }
+          for (const f of result.filesSkipped) {
+            console.log(`Up to date: ${f}`);
+          }
+        }
+      });
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ export { getTypes } from './commands/types';
 export { runPrebuildCommand } from './commands/prebuild';
 export { listThemes } from './commands/theme';
 export { getInfo } from './commands/info';
+export { generateAgentDocs } from './commands/generate-agent-docs';
 
 // Result types
 export type { ScaffoldResult, ScaffoldOptions } from './commands/scaffold';
@@ -22,3 +23,4 @@ export type { TypesResult, ContentTypeEntry, FieldEntry } from './commands/types
 export type { PrebuildResult } from './commands/prebuild';
 export type { ThemeListResult } from './commands/theme';
 export type { InfoResult, PackageVersions } from './commands/info';
+export type { GenerateAgentDocsResult } from './commands/generate-agent-docs';


### PR DESCRIPTION
Closes #83

## Summary

- Adds `stackwright generate-agent-docs` CLI command that introspects live Zod schemas and regenerates the content type reference tables in both `/AGENTS.md` and `examples/hellostackwrightnext/AGENTS.md`
- Tables are bounded by `<!-- stackwright:content-type-table:start/end -->` HTML comment markers so only the table sections are replaced (surrounding docs preserved)
- Schema name registry maps Zod schema object references to human-readable display names (`TextBlock`, `MediaItem`, etc.) — field types render as `heading (TextBlock)` not `heading (object)`
- Adds `check-agent-docs` CI job that runs the generator and fails with an actionable message if AGENTS.md is out of sync with the schemas
- `generateAgentDocs()` exported from `@stackwright/cli` for programmatic/MCP use
- Updated `CLAUDE.md` maintenance rule to use the new command instead of manual table edits

**Bug fixes included:**
- Fixed `resolveSchema` to handle `optional(lazy(...))` nesting — `tabbed_content` previously showed empty required fields due to the lazy schema not being unwrapped after the optional wrapper
- Fixed union type handler to recurse for non-object members, so `z.union([z.number(), z.string()])` renders as `number | string` instead of `object | object`

## Test plan

- [ ] `pnpm stackwright -- generate-agent-docs` runs cleanly and updates AGENTS.md
- [ ] Running the command twice produces no changes on the second run (idempotent)
- [ ] All 112 existing tests pass (`pnpm test`)
- [ ] CI `check-agent-docs` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)