### PR TITLE
docs: document STACKWRIGHT_DEBUG flag and debug logging pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,29 @@ Add these hooks to the example app's `package.json` (already done in `hellostack
 
 `registerNextJSComponents()` from `@stackwright/nextjs` must be called explicitly before rendering — it registers Next.js Image, Link, Router, and Route adapters into the `stackwrightRegistry`. The registration call should live in `pages/_app.tsx` (Pages Router) or `app/layout.tsx` (App Router). Do not rely on module import side effects to trigger registration.
 
+### Debug Logging
+
+Stackwright uses `STACKWRIGHT_DEBUG=true` (set in `.env.local`) to gate verbose console logging. Debug output only activates when both `NODE_ENV === 'development'` and `STACKWRIGHT_DEBUG === 'true'`.
+
+**Pattern for new modules:** Define a module-scoped debug function with a unique emoji prefix:
+
+```typescript
+const debugLog = (message: string, data?: any) => {
+  if (process.env.NODE_ENV === 'development' && process.env.STACKWRIGHT_DEBUG === 'true') {
+    console.log(`🏷️ ModuleName Debug: ${message}`, data ? data : '');
+  }
+};
+```
+
+**Existing prefixes** (do not reuse):
+- `🐛` ContentRenderer — `🔧` ComponentRegistry — `🚀` StackwrightRegistry — `📸` NextStackwrightImage
+
+**Rules:**
+- Use the helper function pattern (not inline conditionals) for consistency.
+- Log at key decision points: component lookups, registration, content type resolution, error paths.
+- Never log sensitive data (user input, credentials).
+- Do not use `console.debug` or other log levels — always `console.log` gated by the env check.
+
 ### Troubleshooting
 
 - **ESM "Cannot find module" errors**: Missing `.js` extensions in ESM imports in built output. Also check that no `packages/*` package.json has `"type": "module"` set.

--- a/examples/hellostackwrightnext/README.md
+++ b/examples/hellostackwrightnext/README.md
@@ -143,6 +143,29 @@ This example demonstrates the core Stackwright architecture:
 4. **Build**: Run `pnpm build` to compile the application
 5. **Development**: Use `pnpm dev` for hot-reloading development
 
+## Debugging
+
+Set `STACKWRIGHT_DEBUG=true` in `.env.local` to enable verbose logging from Stackwright internals. This is off by default.
+
+```bash
+cp .env.local.example .env.local
+# Uncomment STACKWRIGHT_DEBUG=true
+```
+
+When enabled, you'll see prefixed debug output in the browser console and server logs:
+
+- `🐛 ContentRenderer Debug` — YAML-to-React rendering pipeline (content type resolution, item processing)
+- `🔧 ComponentRegistry Debug` — component lookups and registration
+- `🚀 StackwrightRegistry Debug` — framework component registration (Image, Link, Router)
+- `📸 NextStackwrightImage Debug` — Next.js Image wrapper props and resolution
+
+This is useful when:
+- A content type isn't rendering and you need to see how the renderer resolves it
+- Components appear missing or unregistered
+- Image paths aren't resolving correctly
+
+**Note:** Debug logging only activates in development mode (`NODE_ENV=development`). It has no effect in production builds.
+
 ## Troubleshooting
 
 - **Missing Components**: Ensure all required components are registered in the component registry


### PR DESCRIPTION
## Summary
- Adds a **Debugging** section to the example app README explaining how to enable `STACKWRIGHT_DEBUG`, what each emoji-prefixed log channel covers, and when to use it
- Adds a **Debug Logging** section to CLAUDE.md with the canonical pattern for contributors/agents: helper function template, existing prefix registry, and rules for consistency

Closes #110

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify CLAUDE.md guidance matches existing debug logging in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)