### PR TITLE
feat(core): add syntax highlighting to CodeBlock (#105)

### DIFF
--- a/.changeset/syntax-highlighting-code-block.md
+++ b/.changeset/syntax-highlighting-code-block.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/core": minor
+---
+
+Add syntax highlighting to CodeBlock component using Prism.js. Supports JavaScript, TypeScript, Python, YAML, HTML, CSS, JSON, bash, JSX, and TSX with inline-styled tokens. Unsupported languages fall back gracefully to plain text.

--- a/examples/hellostackwrightnext/pages/showcase/content.yml
+++ b/examples/hellostackwrightnext/pages/showcase/content.yml
@@ -198,13 +198,22 @@ content:
 
     # --- code_block ---
 
+    - main:
+        label: "code-block-heading"
+        heading:
+          text: "code_block"
+          textSize: "h2"
+        textBlocks:
+          - text: "Syntax-highlighted code blocks with line numbers. Supports JavaScript, TypeScript, Python, YAML, HTML, CSS, JSON, bash, JSX, and TSX."
+            textSize: "body1"
+
     - code_block:
-        label: "code-block-demo"
+        label: "code-block-yaml-demo"
         language: "yaml"
         lineNumbers: true
         background: "#f8f9fa"
         code: |
-            # code_block — formatted code with syntax highlighting
+            # A Stackwright page defined in YAML
             content:
               content_items:
                 - main:
@@ -215,6 +224,45 @@ content:
                     textBlocks:
                       - text: "My first Stackwright page."
                         textSize: "body1"
+
+    - code_block:
+        label: "code-block-ts-demo"
+        language: "typescript"
+        lineNumbers: true
+        background: "#f8f9fa"
+        code: |
+            import { registerContentType } from '@stackwright/core';
+            import { z } from 'zod';
+
+            // Register a custom content type with Zod validation
+            const chartSchema = z.object({
+              title: z.string(),
+              dataUrl: z.string().url(),
+              height: z.number().optional().default(400),
+            });
+
+            type ChartProps = z.infer<typeof chartSchema>;
+
+            function Chart({ title, dataUrl, height }: ChartProps) {
+              return <div style={{ height }}>{title}</div>;
+            }
+
+            registerContentType('chart', chartSchema, Chart);
+
+    - code_block:
+        label: "code-block-bash-demo"
+        language: "bash"
+        background: "#f8f9fa"
+        code: |
+            # Scaffold a new Stackwright project
+            npx create-stackwright my-site
+            cd my-site && pnpm install
+
+            # Start the dev server
+            pnpm dev
+
+            # Validate all content before deploying
+            pnpm stackwright -- validate-pages
 
     # --- feature_list ---
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,20 +38,22 @@
         "prepublishOnly": "npm run build"
     },
     "dependencies": {
-        "@stackwright/types": "workspace:*",
         "@stackwright/themes": "workspace:*",
+        "@stackwright/types": "workspace:*",
         "js-yaml": "^4.1.0",
-        "zod": "^4.3.6",
-        "uuid": "^13.0.0"
+        "prismjs": "^1.30.0",
+        "uuid": "^13.0.0",
+        "zod": "^4.3.6"
     },
     "devDependencies": {
+        "@stackwright/types": "workspace:*",
         "@swc/core": "^1.15.18",
         "@testing-library/jest-dom": "^6.6",
         "@testing-library/react": "^16.3",
         "@types/node": "^25.3",
+        "@types/prismjs": "^1.26.6",
         "@types/react": "^19.1",
         "@types/react-dom": "^19.2",
-        "@stackwright/types": "workspace:*",
         "@vitest/ui": "^4.0.18",
         "jsdom": "^28.1.0",
         "react": "^19",

--- a/packages/core/src/components/base/CodeBlock.tsx
+++ b/packages/core/src/components/base/CodeBlock.tsx
@@ -1,6 +1,25 @@
 import React from "react";
 import { CodeBlockContent } from "@stackwright/types";
 import { useSafeTheme } from "../../hooks/useSafeTheme";
+import { highlightCode, getTokenColor, HighlightToken } from "../../utils/prismHighlighter";
+
+/**
+ * Split a flat token list into per-line groups so each line can be
+ * rendered independently (required for line-number alignment).
+ */
+function splitTokensByLine(tokens: HighlightToken[]): HighlightToken[][] {
+    const lines: HighlightToken[][] = [[]];
+    for (const token of tokens) {
+        const parts = token.content.split("\n");
+        for (let p = 0; p < parts.length; p++) {
+            if (p > 0) lines.push([]);
+            if (parts[p].length > 0) {
+                lines[lines.length - 1].push({ type: token.type, content: parts[p] });
+            }
+        }
+    }
+    return lines;
+}
 
 export function CodeBlock({
     code,
@@ -10,7 +29,8 @@ export function CodeBlock({
 }: CodeBlockContent) {
     const theme = useSafeTheme();
 
-    const lines = code.trimEnd().split("\n");
+    const tokens = highlightCode(code.trimEnd(), language);
+    const tokenLines = splitTokensByLine(tokens);
 
     return (
         <div
@@ -57,7 +77,7 @@ export function CodeBlock({
                         color: theme.colors.text,
                     }}
                 >
-                    {lines.map((line, i) => (
+                    {tokenLines.map((lineTokens, i) => (
                         <span
                             key={i}
                             style={{ display: "flex", gap: '16px' }}
@@ -75,7 +95,20 @@ export function CodeBlock({
                                     {i + 1}
                                 </span>
                             )}
-                            <span>{line}</span>
+                            <span>
+                                {lineTokens.length > 0
+                                    ? lineTokens.map((t, j) => {
+                                          const color = getTokenColor(t.type);
+                                          return color ? (
+                                              <span key={j} style={{ color }}>
+                                                  {t.content}
+                                              </span>
+                                          ) : (
+                                              <span key={j}>{t.content}</span>
+                                          );
+                                      })
+                                    : " "}
+                            </span>
                             {"\n"}
                         </span>
                     ))}

--- a/packages/core/src/utils/prismHighlighter.ts
+++ b/packages/core/src/utils/prismHighlighter.ts
@@ -1,0 +1,133 @@
+import Prism from 'prismjs';
+
+// Load language grammars
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-yaml';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-markup'; // HTML/XML
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-tsx';
+
+// Map common language aliases to Prism grammar keys
+const LANGUAGE_ALIASES: Record<string, string> = {
+    js: 'javascript',
+    ts: 'typescript',
+    py: 'python',
+    yml: 'yaml',
+    html: 'markup',
+    xml: 'markup',
+    sh: 'bash',
+    shell: 'bash',
+};
+
+/**
+ * Inline color palette for syntax tokens.
+ * Designed for the light (#f4f4f5) code block background.
+ */
+const TOKEN_COLORS: Record<string, string> = {
+    comment: '#6a737d',
+    prolog: '#6a737d',
+    doctype: '#6a737d',
+    cdata: '#6a737d',
+    punctuation: '#24292e',
+    property: '#005cc5',
+    tag: '#22863a',
+    boolean: '#005cc5',
+    number: '#005cc5',
+    constant: '#005cc5',
+    symbol: '#005cc5',
+    selector: '#6f42c1',
+    'attr-name': '#6f42c1',
+    string: '#032f62',
+    char: '#032f62',
+    'template-string': '#032f62',
+    builtin: '#6f42c1',
+    inserted: '#22863a',
+    operator: '#d73a49',
+    entity: '#005cc5',
+    url: '#032f62',
+    keyword: '#d73a49',
+    'attr-value': '#032f62',
+    function: '#6f42c1',
+    'class-name': '#6f42c1',
+    regex: '#032f62',
+    important: '#d73a49',
+    variable: '#e36209',
+    deleted: '#d73a49',
+    atrule: '#d73a49',
+};
+
+/** A flattened token with type and text, ready for rendering. */
+export interface HighlightToken {
+    type: string | null; // null = plain text
+    content: string;
+}
+
+/**
+ * Resolve a language string to a Prism grammar key.
+ * Returns undefined if the language is not supported.
+ */
+function resolveLanguage(language: string): string | undefined {
+    const lower = language.toLowerCase();
+    const resolved = LANGUAGE_ALIASES[lower] ?? lower;
+    return Prism.languages[resolved] ? resolved : undefined;
+}
+
+/**
+ * Flatten Prism's nested token tree into a flat list of HighlightTokens.
+ */
+function flattenTokens(
+    tokens: (string | Prism.Token)[],
+    parentType?: string,
+): HighlightToken[] {
+    const result: HighlightToken[] = [];
+    for (const token of tokens) {
+        if (typeof token === 'string') {
+            result.push({ type: parentType ?? null, content: token });
+        } else {
+            const type = token.type;
+            if (Array.isArray(token.content)) {
+                result.push(...flattenTokens(token.content as (string | Prism.Token)[], type));
+            } else if (typeof token.content === 'string') {
+                result.push({ type, content: token.content });
+            } else {
+                // Single nested token
+                result.push(
+                    ...flattenTokens([token.content as Prism.Token], type),
+                );
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Tokenize code with Prism and return flat highlight tokens.
+ * Returns plain-text tokens if the language is unsupported.
+ */
+export function highlightCode(code: string, language?: string): HighlightToken[] {
+    if (!language) {
+        return [{ type: null, content: code }];
+    }
+
+    const resolvedLang = resolveLanguage(language);
+    if (!resolvedLang) {
+        return [{ type: null, content: code }];
+    }
+
+    const grammar = Prism.languages[resolvedLang];
+    const tokens = Prism.tokenize(code, grammar);
+    return flattenTokens(tokens);
+}
+
+/**
+ * Get the inline color for a token type.
+ */
+export function getTokenColor(type: string | null): string | undefined {
+    if (!type) return undefined;
+    return TOKEN_COLORS[type];
+}

--- a/packages/core/test/components/code-block.test.tsx
+++ b/packages/core/test/components/code-block.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CodeBlock } from '../../src/components/base/CodeBlock';
+
+describe('CodeBlock', () => {
+    it('renders plain code without a language', () => {
+        render(<CodeBlock code="hello world" />);
+        expect(screen.getByText('hello world')).toBeInTheDocument();
+    });
+
+    it('renders the language label when provided', () => {
+        render(<CodeBlock code="x = 1" language="python" />);
+        expect(screen.getByText('python')).toBeInTheDocument();
+    });
+
+    it('does not render a language label when omitted', () => {
+        const { container } = render(<CodeBlock code="x = 1" />);
+        // The label div should not exist — only the pre block
+        const pre = container.querySelector('pre');
+        expect(pre).toBeTruthy();
+        // No sibling div before the pre (language label bar)
+        expect(pre?.previousElementSibling).toBeNull();
+    });
+
+    it('renders line numbers when lineNumbers is true', () => {
+        render(<CodeBlock code={"line one\nline two\nline three"} lineNumbers />);
+        expect(screen.getByText('1')).toBeInTheDocument();
+        expect(screen.getByText('2')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('does not render line numbers by default', () => {
+        render(<CodeBlock code={"alpha\nbeta"} />);
+        expect(screen.queryByText('1')).not.toBeInTheDocument();
+        expect(screen.queryByText('2')).not.toBeInTheDocument();
+    });
+
+    it('produces colored spans for a known language', () => {
+        const jsCode = 'const x = 42;';
+        const { container } = render(
+            <CodeBlock code={jsCode} language="javascript" />,
+        );
+        const pre = container.querySelector('pre')!;
+        // Prism should produce spans with inline color styles for tokens
+        const coloredSpans = pre.querySelectorAll('span[style*="color"]');
+        expect(coloredSpans.length).toBeGreaterThan(0);
+    });
+
+    it('renders plain text for an unknown language without crashing', () => {
+        const code = 'some random text';
+        render(<CodeBlock code={code} language="brainfuck" />);
+        expect(screen.getByText(code)).toBeInTheDocument();
+        // Language label should still appear
+        expect(screen.getByText('brainfuck')).toBeInTheDocument();
+    });
+
+    it('handles empty code string', () => {
+        const { container } = render(<CodeBlock code="" />);
+        const pre = container.querySelector('pre');
+        expect(pre).toBeTruthy();
+    });
+
+    it('highlights TypeScript correctly via alias "ts"', () => {
+        const tsCode = 'function greet(name: string): void {}';
+        const { container } = render(
+            <CodeBlock code={tsCode} language="ts" />,
+        );
+        const pre = container.querySelector('pre')!;
+        const coloredSpans = pre.querySelectorAll('span[style*="color"]');
+        expect(coloredSpans.length).toBeGreaterThan(0);
+    });
+
+    it('highlights YAML content', () => {
+        const yamlCode = 'key: value\nlist:\n  - item1';
+        const { container } = render(
+            <CodeBlock code={yamlCode} language="yaml" />,
+        );
+        const pre = container.querySelector('pre')!;
+        const coloredSpans = pre.querySelectorAll('span[style*="color"]');
+        expect(coloredSpans.length).toBeGreaterThan(0);
+    });
+
+    it('highlights bash/shell content', () => {
+        const bashCode = 'echo "hello" && cd /tmp';
+        const { container } = render(
+            <CodeBlock code={bashCode} language="bash" />,
+        );
+        const pre = container.querySelector('pre')!;
+        const coloredSpans = pre.querySelectorAll('span[style*="color"]');
+        expect(coloredSpans.length).toBeGreaterThan(0);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
+      prismjs:
+        specifier: ^1.30.0
+        version: 1.30.0
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -191,6 +194,9 @@ importers:
       '@types/node':
         specifier: ^24.1.0
         version: 24.2.1
+      '@types/prismjs':
+        specifier: ^1.26.6
+        version: 1.26.6
       '@types/react':
         specifier: ^19.1
         version: 19.1.9
@@ -2081,6 +2087,9 @@ packages:
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
 
+  '@types/prismjs@1.26.6':
+    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
+
   '@types/react-dom@19.1.7':
     resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
     peerDependencies:
@@ -3844,6 +3853,10 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -5901,6 +5914,8 @@ snapshots:
     dependencies:
       undici-types: 7.10.0
 
+  '@types/prismjs@1.26.6': {}
+
   '@types/react-dom@19.1.7(@types/react@19.1.9)':
     dependencies:
       '@types/react': 19.1.9
@@ -6080,6 +6095,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
@@ -6087,6 +6110,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.2.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.2.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -6114,7 +6145,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.11.0)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@24.2.1)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -7825,6 +7856,8 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prismjs@1.30.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8544,7 +8577,7 @@ snapshots:
   vitest@4.0.18(@types/node@24.10.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -8622,7 +8655,7 @@ snapshots:
   vitest@4.0.18(@types/node@24.2.1)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.2.1)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18


### PR DESCRIPTION
## Summary
- Add Prism.js-based syntax highlighting to the `CodeBlock` component with inline-styled tokens (no CSS dependency — fits core's no-CSS-pipeline architecture)
- Support for JavaScript, TypeScript, Python, YAML, HTML/XML, CSS, JSON, bash/shell, JSX, and TSX (with common aliases like `js`, `ts`, `py`, `yml`, `sh`)
- Unsupported languages fall back gracefully to plain text rendering
- Showcase page updated with multi-language demos (YAML, TypeScript, bash)

## Test plan
- [x] 11 new unit tests in `packages/core/test/components/code-block.test.tsx`
- [x] All 153 tests pass (`pnpm test`)
- [x] `pnpm build` succeeds
- [ ] Visual check: `pnpm dev:hellostackwright` → /showcase page shows colored syntax in code blocks

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)