### PR TITLE
fix(core): add keyboard navigation and accessibility to Carousel

### DIFF
--- a/.changeset/carousel-keyboard-nav.md
+++ b/.changeset/carousel-keyboard-nav.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/core": patch
+---
+
+Add keyboard navigation and accessibility to Carousel component. Arrow keys navigate between slides, proper ARIA attributes (role, aria-roledescription, aria-live, aria-label) support screen readers, and a visible focus indicator aids keyboard users.

--- a/packages/core/src/components/narrative/Carousel/Carousel.tsx
+++ b/packages/core/src/components/narrative/Carousel/Carousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { OverflowImageCard } from './OverFlowImageCard';
 import { CarouselContent } from '@stackwright/types'
 import { useSafeTheme } from '../../../hooks/useSafeTheme';
@@ -34,6 +34,8 @@ export const Carousel = (carouselContent: CarouselContent) => {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [lastInteraction, setLastInteraction] = useState(Date.now())
   const [isTransitioning, setIsTransitioning] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
   const safeTheme = useSafeTheme()
   const { isXs, isSmUp, isMdUp, isLgUp } = useBreakpoints()
 
@@ -60,12 +62,7 @@ export const Carousel = (carouselContent: CarouselContent) => {
     }, 150)
   }, [carouselContent.items.length, itemsToShow])
 
-  const manualNext = () => {
-    setLastInteraction(Date.now())
-    next()
-  }
-
-  const prev = () => {
+  const prev = useCallback(() => {
     setLastInteraction(Date.now())
     setIsTransitioning(true)
     setTimeout(() => {
@@ -77,7 +74,12 @@ export const Carousel = (carouselContent: CarouselContent) => {
       })
       setTimeout(() => setIsTransitioning(false), 50)
     }, 150)
-  }
+  }, [carouselContent.items.length, itemsToShow])
+
+  const manualNext = useCallback(() => {
+    setLastInteraction(Date.now())
+    next()
+  }, [next])
 
   useEffect(() => {
     if (carouselContent.autoPlay && scrollAndButtonsEnabled) {
@@ -95,10 +97,30 @@ export const Carousel = (carouselContent: CarouselContent) => {
     setCurrentIndex(0)
   }, [itemsToShow])
 
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (!scrollAndButtonsEnabled) return
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      prev()
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      manualNext()
+    }
+  }, [scrollAndButtonsEnabled, prev, manualNext])
+
   const background = carouselContent.background || safeTheme.colors.primary;
 
   return (
     <div
+      ref={containerRef}
+      role="region"
+      aria-roledescription="carousel"
+      aria-label={carouselContent.heading || 'Carousel'}
+      aria-live={carouselContent.autoPlay ? 'off' : 'polite'}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
       style={{
         display: 'flex',
         flexDirection: 'row',
@@ -108,6 +130,8 @@ export const Carousel = (carouselContent: CarouselContent) => {
         height: '80%',
         padding: '16px',
         overflowY: 'visible',
+        outline: isFocused ? '2px solid currentColor' : 'none',
+        outlineOffset: '-2px',
       }}
     >
       {scrollAndButtonsEnabled && (
@@ -126,11 +150,17 @@ export const Carousel = (carouselContent: CarouselContent) => {
         }}
       >
         {carouselContent.items.slice(currentIndex, currentIndex + itemsToShow).map((item, index) => (
-          <OverflowImageCard
+          <div
             key={`${currentIndex}-${index}-${item.title}`}
-            item={item}
-            minWidth="100%"
-          />
+            role="group"
+            aria-roledescription="slide"
+            aria-label={`Slide ${currentIndex + index + 1} of ${carouselContent.items.length}`}
+          >
+            <OverflowImageCard
+              item={item}
+              minWidth="100%"
+            />
+          </div>
         ))}
       </div>
 

--- a/packages/core/test/components/carousel.test.tsx
+++ b/packages/core/test/components/carousel.test.tsx
@@ -1,0 +1,344 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+// Mock useBreakpoints before importing Carousel
+const mockBreakpoints = {
+    isXs: false, isSm: false, isMd: false, isLg: false, isXl: false,
+    isSmUp: false, isMdUp: false, isLgUp: false, isXlUp: false,
+    isSmDown: false, isMdDown: false, isLgDown: false,
+    breakpoints: {},
+};
+
+vi.mock('../../src/hooks/useBreakpoints', () => ({
+    useBreakpoints: () => mockBreakpoints,
+}));
+
+vi.mock('../../src/hooks/useSafeTheme', () => ({
+    useSafeTheme: () => ({
+        colors: {
+            primary: '#1976d2',
+            accent: '#ff9800',
+            text: '#333333',
+            background: '#ffffff',
+        },
+        typography: {},
+        spacing: {},
+    }),
+}));
+
+vi.mock('../../src/components/media/Media', () => ({
+    Media: ({ label }: { label: string }) => <div data-testid={`media-${label}`}>Media</div>,
+}));
+
+import { Carousel } from '../../src/components/narrative/Carousel/Carousel';
+
+const makeItems = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+        title: `Item ${i + 1}`,
+        text: `Description ${i + 1}`,
+        media: { type: 'image' as const, src: `/img/${i + 1}.png`, alt: `Image ${i + 1}` },
+    }));
+
+describe('Carousel', () => {
+    beforeEach(() => {
+        // Default to desktop (lgUp) — shows 4 items
+        Object.assign(mockBreakpoints, {
+            isXs: false, isSm: false, isMd: false, isLg: true, isXl: false,
+            isSmUp: true, isMdUp: true, isLgUp: true, isXlUp: false,
+            isSmDown: false, isMdDown: false, isLgDown: false,
+        });
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders carousel items with titles and text', () => {
+        render(
+            <Carousel
+                label="test-carousel"
+                heading="Test Carousel"
+                items={makeItems(3)}
+            />
+        );
+        expect(screen.getByText('Item 1')).toBeInTheDocument();
+        expect(screen.getByText('Item 2')).toBeInTheDocument();
+        expect(screen.getByText('Item 3')).toBeInTheDocument();
+        expect(screen.getByText('Description 1')).toBeInTheDocument();
+    });
+
+    it('hides navigation buttons when items fit in view', () => {
+        render(
+            <Carousel
+                label="test-carousel"
+                heading="Test Carousel"
+                items={makeItems(3)}
+            />
+        );
+        expect(screen.queryByLabelText('Previous')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Next')).not.toBeInTheDocument();
+    });
+
+    it('shows navigation buttons when items exceed visible slots', () => {
+        render(
+            <Carousel
+                label="test-carousel"
+                heading="Test Carousel"
+                items={makeItems(6)}
+            />
+        );
+        expect(screen.getByLabelText('Previous')).toBeInTheDocument();
+        expect(screen.getByLabelText('Next')).toBeInTheDocument();
+    });
+
+    it('navigates forward on next button click', () => {
+        render(
+            <Carousel
+                label="test-carousel"
+                heading="Test Carousel"
+                items={makeItems(6)}
+            />
+        );
+        expect(screen.getByText('Item 1')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByLabelText('Next'));
+        act(() => { vi.advanceTimersByTime(200); });
+
+        expect(screen.getByText('Item 2')).toBeInTheDocument();
+        expect(screen.getByText('Item 5')).toBeInTheDocument();
+    });
+
+    it('navigates backward on previous button click', () => {
+        render(
+            <Carousel
+                label="test-carousel"
+                heading="Test Carousel"
+                items={makeItems(6)}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Previous'));
+        act(() => { vi.advanceTimersByTime(200); });
+
+        expect(screen.getByText('Item 3')).toBeInTheDocument();
+        expect(screen.getByText('Item 6')).toBeInTheDocument();
+    });
+
+    describe('keyboard navigation', () => {
+        it('navigates forward on ArrowRight key', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test Carousel"
+                    items={makeItems(6)}
+                />
+            );
+            const container = screen.getByRole('region');
+            fireEvent.keyDown(container, { key: 'ArrowRight' });
+            act(() => { vi.advanceTimersByTime(200); });
+
+            expect(screen.getByText('Item 2')).toBeInTheDocument();
+            expect(screen.getByText('Item 5')).toBeInTheDocument();
+        });
+
+        it('navigates backward on ArrowLeft key', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test Carousel"
+                    items={makeItems(6)}
+                />
+            );
+            const container = screen.getByRole('region');
+            fireEvent.keyDown(container, { key: 'ArrowLeft' });
+            act(() => { vi.advanceTimersByTime(200); });
+
+            expect(screen.getByText('Item 3')).toBeInTheDocument();
+            expect(screen.getByText('Item 6')).toBeInTheDocument();
+        });
+
+        it('ignores arrow keys when all items are visible', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test Carousel"
+                    items={makeItems(3)}
+                />
+            );
+            const container = screen.getByRole('region');
+            fireEvent.keyDown(container, { key: 'ArrowRight' });
+            act(() => { vi.advanceTimersByTime(200); });
+
+            expect(screen.getByText('Item 1')).toBeInTheDocument();
+            expect(screen.getByText('Item 2')).toBeInTheDocument();
+            expect(screen.getByText('Item 3')).toBeInTheDocument();
+        });
+    });
+
+    describe('ARIA attributes', () => {
+        it('has role="region" and aria-roledescription="carousel"', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="My Carousel"
+                    items={makeItems(3)}
+                />
+            );
+            const container = screen.getByRole('region');
+            expect(container).toHaveAttribute('aria-roledescription', 'carousel');
+        });
+
+        it('uses heading as aria-label', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Featured Items"
+                    items={makeItems(3)}
+                />
+            );
+            const container = screen.getByRole('region');
+            expect(container).toHaveAttribute('aria-label', 'Featured Items');
+        });
+
+        it('sets aria-live="polite" when autoPlay is off', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    items={makeItems(3)}
+                />
+            );
+            const container = screen.getByRole('region');
+            expect(container).toHaveAttribute('aria-live', 'polite');
+        });
+
+        it('sets aria-live="off" when autoPlay is on', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    autoPlay={true}
+                    items={makeItems(3)}
+                />
+            );
+            const container = screen.getByRole('region');
+            expect(container).toHaveAttribute('aria-live', 'off');
+        });
+
+        it('wraps each item with role="group" and aria-roledescription="slide"', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    items={makeItems(3)}
+                />
+            );
+            const slides = screen.getAllByRole('group');
+            expect(slides).toHaveLength(3);
+            slides.forEach(slide => {
+                expect(slide).toHaveAttribute('aria-roledescription', 'slide');
+            });
+        });
+
+        it('labels each slide with position info', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    items={makeItems(3)}
+                />
+            );
+            expect(screen.getByLabelText('Slide 1 of 3')).toBeInTheDocument();
+            expect(screen.getByLabelText('Slide 2 of 3')).toBeInTheDocument();
+            expect(screen.getByLabelText('Slide 3 of 3')).toBeInTheDocument();
+        });
+    });
+
+    describe('focus management', () => {
+        it('is focusable via tabIndex', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    items={makeItems(3)}
+                />
+            );
+            const container = screen.getByRole('region');
+            expect(container).toHaveAttribute('tabIndex', '0');
+        });
+
+        it('shows focus indicator on focus', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    items={makeItems(3)}
+                />
+            );
+            const container = screen.getByRole('region');
+            expect(container.style.outline).toBe('none');
+
+            fireEvent.focus(container);
+            expect(container.style.outline).toBe('2px solid currentColor');
+
+            fireEvent.blur(container);
+            expect(container.style.outline).toBe('none');
+        });
+    });
+
+    describe('responsive behavior', () => {
+        it('shows 1 item on extra small screens', () => {
+            Object.assign(mockBreakpoints, {
+                isXs: true, isSm: false, isMd: false, isLg: false, isXl: false,
+                isSmUp: false, isMdUp: false, isLgUp: false, isXlUp: false,
+            });
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    items={makeItems(4)}
+                />
+            );
+            const slides = screen.getAllByRole('group');
+            expect(slides).toHaveLength(1);
+        });
+
+        it('shows 2 items on small screens', () => {
+            Object.assign(mockBreakpoints, {
+                isXs: false, isSm: true, isMd: false, isLg: false, isXl: false,
+                isSmUp: true, isMdUp: false, isLgUp: false, isXlUp: false,
+            });
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    items={makeItems(4)}
+                />
+            );
+            const slides = screen.getAllByRole('group');
+            expect(slides).toHaveLength(2);
+        });
+    });
+
+    describe('auto-play', () => {
+        it('auto-advances when autoPlay is enabled', () => {
+            render(
+                <Carousel
+                    label="test-carousel"
+                    heading="Test"
+                    autoPlay={true}
+                    autoPlaySpeed={1000}
+                    items={makeItems(6)}
+                />
+            );
+            expect(screen.getByText('Item 1')).toBeInTheDocument();
+
+            act(() => { vi.advanceTimersByTime(1200); });
+
+            expect(screen.getByText('Item 2')).toBeInTheDocument();
+            expect(screen.getByText('Item 5')).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add arrow key (Left/Right) navigation to the Carousel component when items exceed visible slots
- Add ARIA attributes: `role="region"`, `aria-roledescription="carousel"`, `aria-live` (polite/off for auto-play), slide-level `role="group"` with positional labels
- Add visible focus indicator and `tabIndex={0}` for keyboard focusability
- Add 19 unit tests covering rendering, click/keyboard navigation, ARIA attributes, focus management, responsive behavior, and auto-play

Closes #111

## Test plan

- [x] `pnpm test:core` — all 142 tests pass (19 new)
- [x] `pnpm build:core` — builds successfully
- [x] Manual verification: focus carousel with Tab, navigate with arrow keys
- [ ] Screen reader verification: ARIA attributes announce correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)