### PR TITLE
feat(mcp): add read/write page and site config tools (#103)

### DIFF
--- a/.changeset/mcp-read-write-tools.md
+++ b/.changeset/mcp-read-write-tools.md
@@ -1,0 +1,6 @@
+---
+"@stackwright/cli": minor
+"@stackwright/mcp": minor
+---
+
+Add MCP tools for reading and writing page content and site configuration. New tools: `stackwright_get_page` (read page YAML by slug), `stackwright_write_page` (write/update page YAML with validation), and `stackwright_get_site_config` (read site config YAML). Also adds corresponding CLI commands `page get`, `page write`, and `site get`.

--- a/packages/cli/src/commands/page.ts
+++ b/packages/cli/src/commands/page.ts
@@ -105,6 +105,78 @@ export function validatePages(pagesDir: string, slug?: string): PageValidateResu
   return { valid: errors.length === 0, errors };
 }
 
+export interface ReadPageResult {
+  slug: string;
+  content: string;
+  path: string;
+}
+
+export function readPage(pagesDir: string, slug: string): ReadPageResult {
+  const normalizedSlug = slug.startsWith('/') ? slug : `/${slug}`;
+  const { pages } = listPages(pagesDir);
+  const page = pages.find((p) => p.slug === normalizedSlug);
+
+  if (!page) {
+    const err = new Error(`Page not found: "${normalizedSlug}"`);
+    (err as NodeJS.ErrnoException).code = 'PAGE_NOT_FOUND';
+    throw err;
+  }
+
+  const content = fs.readFileSync(page.path, 'utf8');
+  return { slug: page.slug, content, path: page.path };
+}
+
+export interface WritePageResult {
+  slug: string;
+  path: string;
+  created: boolean;
+}
+
+export function writePage(
+  pagesDir: string,
+  slug: string,
+  yamlContent: string
+): WritePageResult {
+  const cleanSlug = slug.replace(/^\//, '').replace(/\\/g, '/');
+
+  // Prevent path traversal
+  const resolvedTarget = path.resolve(pagesDir, cleanSlug);
+  if (!resolvedTarget.startsWith(path.resolve(pagesDir) + path.sep) && resolvedTarget !== path.resolve(pagesDir)) {
+    const err = new Error(`Invalid slug: "${slug}"`);
+    (err as NodeJS.ErrnoException).code = 'INVALID_SLUG';
+    throw err;
+  }
+
+  // Parse and validate YAML before writing
+  let raw: unknown;
+  try {
+    raw = yaml.load(yamlContent);
+  } catch (parseErr) {
+    const err = new Error(`YAML parse error: ${formatError(parseErr)}`);
+    (err as NodeJS.ErrnoException).code = 'YAML_PARSE_ERROR';
+    throw err;
+  }
+
+  const result = pageContentSchema.safeParse(raw);
+  if (!result.success) {
+    const fieldErrors = result.error.issues.map((issue) => {
+      const fieldPath = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+      return `${fieldPath}: ${issue.message}`;
+    });
+    const err = new Error(`Validation failed:\n  ${fieldErrors.join('\n  ')}`);
+    (err as NodeJS.ErrnoException).code = 'VALIDATION_FAILED';
+    throw err;
+  }
+
+  const contentPath = path.join(pagesDir, cleanSlug, 'content.yml');
+  const created = !fs.existsSync(contentPath);
+
+  fs.ensureDirSync(path.dirname(contentPath));
+  fs.writeFileSync(contentPath, yamlContent, 'utf8');
+
+  return { slug: `/${cleanSlug}`, path: contentPath, created };
+}
+
 export interface AddPageResult {
   path: string;
   slug: string;
@@ -182,6 +254,63 @@ export function registerPage(program: Command): void {
           outputError(formatError(err), 'NOT_A_PROJECT', { json });
         } else {
           outputError(formatError(err), 'ADD_PAGE_FAILED', { json }, 2);
+        }
+      }
+    });
+
+  page
+    .command('get <slug>')
+    .description('Read a page\'s raw YAML content by slug')
+    .option('--json', 'Output machine-readable JSON')
+    .action((slug: string, opts: { json?: boolean }) => {
+      const json = Boolean(opts.json);
+      try {
+        const { pagesDir } = detectProject();
+        const result = readPage(pagesDir, slug);
+        outputResult(result, { json }, () => {
+          console.log(result.content);
+        });
+      } catch (err: unknown) {
+        const code = getErrorCode(err);
+        if (code === 'NOT_A_PROJECT' || code === 'PAGE_NOT_FOUND') {
+          outputError(formatError(err), code, { json });
+        } else {
+          outputError(formatError(err), 'READ_PAGE_FAILED', { json }, 2);
+        }
+      }
+    });
+
+  page
+    .command('write <slug>')
+    .description('Write YAML content to a page (validates before writing)')
+    .option('--json', 'Output machine-readable JSON')
+    .option('--file <path>', 'Read YAML content from a file instead of stdin')
+    .action(async (slug: string, opts: { json?: boolean; file?: string }) => {
+      const json = Boolean(opts.json);
+      try {
+        const { pagesDir } = detectProject();
+        let yamlContent: string;
+        if (opts.file) {
+          yamlContent = fs.readFileSync(opts.file, 'utf8');
+        } else {
+          // Read from stdin
+          const chunks: Buffer[] = [];
+          for await (const chunk of process.stdin) {
+            chunks.push(chunk);
+          }
+          yamlContent = Buffer.concat(chunks).toString('utf8');
+        }
+        const result = writePage(pagesDir, slug, yamlContent);
+        outputResult(result, { json }, () => {
+          const verb = result.created ? 'Created' : 'Updated';
+          console.log(chalk.green(`${verb} page "${result.slug}" at ${result.path}`));
+        });
+      } catch (err: unknown) {
+        const code = getErrorCode(err);
+        if (code === 'NOT_A_PROJECT' || code === 'VALIDATION_FAILED' || code === 'YAML_PARSE_ERROR' || code === 'INVALID_SLUG') {
+          outputError(formatError(err), code, { json });
+        } else {
+          outputError(formatError(err), 'WRITE_PAGE_FAILED', { json }, 2);
         }
       }
     });

--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -8,8 +8,24 @@ import { siteConfigSchema } from '../utils/schema-loader';
 import { outputResult, outputError, getErrorCode, formatError } from '../utils/json-output';
 
 // ---------------------------------------------------------------------------
-// Pure function
+// Pure functions
 // ---------------------------------------------------------------------------
+
+export interface ReadSiteConfigResult {
+  content: string;
+  path: string;
+}
+
+export function readSiteConfig(siteConfigPath: string): ReadSiteConfigResult {
+  if (!fs.existsSync(siteConfigPath)) {
+    const err = new Error(`Site config not found: ${siteConfigPath}`);
+    (err as NodeJS.ErrnoException).code = 'NOT_A_PROJECT';
+    throw err;
+  }
+
+  const content = fs.readFileSync(siteConfigPath, 'utf8');
+  return { content, path: siteConfigPath };
+}
 
 export interface SiteValidationError {
   field: string;
@@ -49,6 +65,27 @@ export function validateSite(siteConfigPath: string): SiteValidateResult {
 
 export function registerSite(program: Command): void {
   const site = program.command('site').description('Manage site configuration');
+
+  site
+    .command('get')
+    .description('Read the raw YAML content of stackwright.yml')
+    .option('--json', 'Output machine-readable JSON')
+    .action((opts: { json?: boolean }) => {
+      const json = Boolean(opts.json);
+      try {
+        const { siteConfig } = detectProject();
+        const result = readSiteConfig(siteConfig);
+        outputResult(result, { json }, () => {
+          console.log(result.content);
+        });
+      } catch (err: unknown) {
+        if (getErrorCode(err) === 'NOT_A_PROJECT') {
+          outputError(formatError(err), 'NOT_A_PROJECT', { json });
+        } else {
+          outputError(formatError(err), 'READ_SITE_FAILED', { json }, 2);
+        }
+      }
+    });
 
   site
     .command('validate')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,8 +7,8 @@ export { outputResult, outputError } from './utils/json-output';
 
 // Pure command functions — callable as a library without spawning a subprocess
 export { scaffold } from './commands/scaffold';
-export { listPages, addPage, validatePages } from './commands/page';
-export { validateSite } from './commands/site';
+export { listPages, addPage, validatePages, readPage, writePage } from './commands/page';
+export { validateSite, readSiteConfig } from './commands/site';
 export { getTypes } from './commands/types';
 export { runPrebuildCommand } from './commands/prebuild';
 export { listThemes } from './commands/theme';
@@ -17,8 +17,8 @@ export { generateAgentDocs } from './commands/generate-agent-docs';
 
 // Result types
 export type { ScaffoldResult, ScaffoldOptions } from './commands/scaffold';
-export type { PageSummary, PageListResult, PageValidateResult, AddPageResult } from './commands/page';
-export type { SiteValidateResult, SiteValidationError } from './commands/site';
+export type { PageSummary, PageListResult, PageValidateResult, AddPageResult, ReadPageResult, WritePageResult } from './commands/page';
+export type { SiteValidateResult, SiteValidationError, ReadSiteConfigResult } from './commands/site';
 export type { TypesResult, ContentTypeEntry, FieldEntry } from './commands/types';
 export type { PrebuildResult } from './commands/prebuild';
 export type { ThemeListResult } from './commands/theme';

--- a/packages/mcp/src/tools/pages.ts
+++ b/packages/mcp/src/tools/pages.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import path from 'path';
-import { listPages, addPage, validatePages } from '@stackwright/cli';
+import { listPages, addPage, validatePages, readPage, writePage } from '@stackwright/cli';
 
 const PAGES_SUBDIR = 'content/pages';
 
@@ -26,6 +26,79 @@ export function registerPageTools(server: McpServer): void {
           ? 'No pages found.'
           : `Pages (${result.pages.length}):\n${lines.join('\n')}`;
       return { content: [{ type: 'text', text }] };
+    }
+  );
+
+  server.tool(
+    'stackwright_get_page',
+    'Read the raw YAML content of an existing page by slug. Returns the full YAML source.',
+    {
+      projectRoot: z.string().describe('Absolute path to the root of the Stackwright project'),
+      slug: z.string().describe('Page slug, e.g. "about" or "getting-started"'),
+    },
+    async ({ projectRoot, slug }) => {
+      try {
+        const result = readPage(pagesDir(projectRoot), slug);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Page "${result.slug}" (${result.path}):\n\n${result.content}`,
+            },
+          ],
+        };
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        return {
+          content: [
+            {
+              type: 'text',
+              text: code === 'PAGE_NOT_FOUND'
+                ? `Page not found: "${slug}". Use stackwright_list_pages to see available pages.`
+                : `Error reading page: ${String((err as Error).message)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  server.tool(
+    'stackwright_write_page',
+    'Write or update a page\'s YAML content. Validates against the content schema before writing — invalid YAML is rejected with field-level errors.',
+    {
+      projectRoot: z.string().describe('Absolute path to the root of the Stackwright project'),
+      slug: z.string().describe('Page slug, e.g. "about" or "team/leadership"'),
+      content: z.string().describe('The full YAML content for the page'),
+    },
+    async ({ projectRoot, slug, content }) => {
+      try {
+        const result = writePage(pagesDir(projectRoot), slug, content);
+        const verb = result.created ? 'Created' : 'Updated';
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `${verb} page "${result.slug}" at ${result.path}`,
+            },
+          ],
+        };
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        const message = (err as Error).message;
+        return {
+          content: [
+            {
+              type: 'text',
+              text: code === 'VALIDATION_FAILED' || code === 'YAML_PARSE_ERROR'
+                ? message
+                : `Error writing page: ${message}`,
+            },
+          ],
+          isError: true,
+        };
+      }
     }
   );
 

--- a/packages/mcp/src/tools/site.ts
+++ b/packages/mcp/src/tools/site.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import path from 'path';
 import fs from 'fs';
-import { validateSite, listThemes } from '@stackwright/cli';
+import { validateSite, listThemes, readSiteConfig } from '@stackwright/cli';
 
 function resolveSiteConfig(projectRoot: string): string {
   const candidates = ['stackwright.yml', 'stackwright.yaml'];
@@ -14,6 +14,38 @@ function resolveSiteConfig(projectRoot: string): string {
 }
 
 export function registerSiteTools(server: McpServer): void {
+  server.tool(
+    'stackwright_get_site_config',
+    'Read the raw YAML content of the stackwright.yml site configuration file.',
+    {
+      projectRoot: z.string().describe('Absolute path to the root of the Stackwright project'),
+    },
+    async ({ projectRoot }) => {
+      try {
+        const siteConfigPath = resolveSiteConfig(projectRoot);
+        const result = readSiteConfig(siteConfigPath);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Site config (${result.path}):\n\n${result.content}`,
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error reading site config: ${String((err as Error).message)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
   server.tool(
     'stackwright_validate_site',
     'Validate the stackwright.yml site configuration file against the Stackwright site config schema.',

--- a/packages/mcp/test/mcp-tools.test.ts
+++ b/packages/mcp/test/mcp-tools.test.ts
@@ -176,6 +176,115 @@ describe("MCP Tools Integration", () => {
             );
         });
 
+        it("get_page returns page YAML content", async () => {
+            const pageDir = path.join(pagesDir, "about");
+            fs.ensureDirSync(pageDir);
+            const yamlContent = makePageYaml("about", "About Us");
+            fs.writeFileSync(
+                path.join(pageDir, "content.yml"),
+                yamlContent,
+            );
+
+            const server = new McpServer({ name: "test", version: "1.0.0" });
+            registerPageTools(server);
+
+            const tool = (server as any)._registeredTools[
+                "stackwright_get_page"
+            ];
+            const result = await tool.handler({
+                projectRoot: testDir,
+                slug: "about",
+            });
+
+            expect(result.content[0].text).toContain("About Us");
+            expect(result.content[0].text).toContain('Page "/about"');
+            expect(result.isError).toBeFalsy();
+        });
+
+        it("get_page returns error for missing page", async () => {
+            const server = new McpServer({ name: "test", version: "1.0.0" });
+            registerPageTools(server);
+
+            const tool = (server as any)._registeredTools[
+                "stackwright_get_page"
+            ];
+            const result = await tool.handler({
+                projectRoot: testDir,
+                slug: "nonexistent",
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("Page not found");
+        });
+
+        it("write_page writes valid YAML and creates new page", async () => {
+            const server = new McpServer({ name: "test", version: "1.0.0" });
+            registerPageTools(server);
+
+            const tool = (server as any)._registeredTools[
+                "stackwright_write_page"
+            ];
+            const yamlContent = makePageYaml("new-page", "New Page Title");
+            const result = await tool.handler({
+                projectRoot: testDir,
+                slug: "new-page",
+                content: yamlContent,
+            });
+
+            expect(result.content[0].text).toContain('Created page "/new-page"');
+            expect(result.isError).toBeFalsy();
+
+            // Verify file was written
+            const pagePath = path.join(pagesDir, "new-page", "content.yml");
+            expect(fs.existsSync(pagePath)).toBe(true);
+            expect(fs.readFileSync(pagePath, "utf8")).toContain("New Page Title");
+        });
+
+        it("write_page updates existing page", async () => {
+            const pageDir = path.join(pagesDir, "existing");
+            fs.ensureDirSync(pageDir);
+            fs.writeFileSync(
+                path.join(pageDir, "content.yml"),
+                makePageYaml("existing", "Old Title"),
+            );
+
+            const server = new McpServer({ name: "test", version: "1.0.0" });
+            registerPageTools(server);
+
+            const tool = (server as any)._registeredTools[
+                "stackwright_write_page"
+            ];
+            const result = await tool.handler({
+                projectRoot: testDir,
+                slug: "existing",
+                content: makePageYaml("existing", "New Title"),
+            });
+
+            expect(result.content[0].text).toContain('Updated page "/existing"');
+            expect(result.isError).toBeFalsy();
+        });
+
+        it("write_page rejects invalid YAML with field-level errors", async () => {
+            const server = new McpServer({ name: "test", version: "1.0.0" });
+            registerPageTools(server);
+
+            const tool = (server as any)._registeredTools[
+                "stackwright_write_page"
+            ];
+            const result = await tool.handler({
+                projectRoot: testDir,
+                slug: "bad-page",
+                content: "invalid_key: true\n",
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("Validation failed");
+
+            // Verify file was NOT written
+            const pagePath = path.join(pagesDir, "bad-page", "content.yml");
+            expect(fs.existsSync(pagePath)).toBe(false);
+        });
+
         it("validate_pages returns success for valid pages", async () => {
             const pageDir = path.join(pagesDir, "about");
             fs.ensureDirSync(pageDir);
@@ -291,6 +400,37 @@ describe("MCP Tools Integration", () => {
             expect(tools).toContain("stackwright_list_themes");
         });
 
+        it("get_site_config returns site config YAML", async () => {
+            const siteConfigPath = path.join(testDir, "stackwright.yml");
+            fs.writeFileSync(siteConfigPath, makeValidSiteConfig());
+
+            const server = new McpServer({ name: "test", version: "1.0.0" });
+            registerSiteTools(server);
+
+            const tool = (server as any)._registeredTools[
+                "stackwright_get_site_config"
+            ];
+            const result = await tool.handler({ projectRoot: testDir });
+
+            expect(result.content[0].text).toContain("Site config");
+            expect(result.content[0].text).toContain("Test Site");
+            expect(result.content[0].text).toContain("per-aspera");
+            expect(result.isError).toBeFalsy();
+        });
+
+        it("get_site_config returns error when config missing", async () => {
+            const server = new McpServer({ name: "test", version: "1.0.0" });
+            registerSiteTools(server);
+
+            const tool = (server as any)._registeredTools[
+                "stackwright_get_site_config"
+            ];
+            const result = await tool.handler({ projectRoot: testDir });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("Error reading site config");
+        });
+
         it("validate_site returns success for valid config", async () => {
             const siteConfigPath = path.join(testDir, "stackwright.yml");
             fs.writeFileSync(siteConfigPath, makeValidSiteConfig());
@@ -337,15 +477,18 @@ describe("MCP Tools Integration", () => {
             // Verify all expected tools are registered
             expect(tools).toContain("stackwright_get_content_types");
             expect(tools).toContain("stackwright_list_pages");
+            expect(tools).toContain("stackwright_get_page");
+            expect(tools).toContain("stackwright_write_page");
             expect(tools).toContain("stackwright_add_page");
             expect(tools).toContain("stackwright_validate_pages");
             expect(tools).toContain("stackwright_get_project_info");
             expect(tools).toContain("stackwright_scaffold_project");
+            expect(tools).toContain("stackwright_get_site_config");
             expect(tools).toContain("stackwright_validate_site");
             expect(tools).toContain("stackwright_list_themes");
 
-            // Should have exactly 8 tools
-            expect(tools.length).toBe(8);
+            // Should have exactly 11 tools
+            expect(tools.length).toBe(11);
         });
     });
 });


### PR DESCRIPTION
## Summary

Closes #103. Adds three new MCP tools that complete the content read/write loop for AI agents:

- **`stackwright_get_page`** — read existing page YAML content by slug
- **`stackwright_write_page`** — write/update page YAML with pre-write Zod validation (invalid content is rejected with field-level errors)
- **`stackwright_get_site_config`** — read the site configuration YAML

Also adds corresponding CLI commands (`page get`, `page write`, `site get`) and pure functions (`readPage`, `writePage`, `readSiteConfig`) exported from `@stackwright/cli` for programmatic use.

## Test plan

- [x] 7 new MCP tool tests (21 total, all passing)
- [x] All 195 monorepo tests pass (`pnpm test`)
- [x] CLI and MCP packages build successfully
- [ ] Manual: `cd examples/hellostackwrightnext && pnpm stackwright -- page get getting-started`
- [ ] Manual: `cd examples/hellostackwrightnext && pnpm stackwright -- site get`

🤖 Generated with [Claude Code](https://claude.com/claude-code)