### PR TITLE
fix(ci): resolve dependabot merge conflict markers in workflow files

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,11 +16,7 @@ jobs:
     steps:
       - name: Generate PerAsperaCI token
         id: app-token
-<<<<<<< dependabot/github_actions/actions/upload-artifact-7
         uses: actions/create-github-app-token@v2
-=======
-        uses: actions/create-github-app-token@v1
->>>>>>> dev
         with:
           app-id: ${{ secrets.PERASPECRACI_APP_ID }}
           private-key: ${{ secrets.PERASPERA_CI_PRIVATE_KEY }}

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -17,11 +17,7 @@ jobs:
     steps:
       - name: Generate PerAsperaCI token
         id: app-token
-<<<<<<< dependabot/github_actions/actions/upload-artifact-7
         uses: actions/create-github-app-token@v2
-=======
-        uses: actions/create-github-app-token@v1
->>>>>>> dev
         with:
           app-id: ${{ secrets.PERASPECRACI_APP_ID }}
           private-key: ${{ secrets.PERASPERA_CI_PRIVATE_KEY }}


### PR DESCRIPTION
## What

Resolves unresolved merge conflict markers in `.github/workflows/prerelease.yml` and `.github/workflows/update-snapshots.yml` left over from a dependabot PR that bumped `actions/create-github-app-token` from v1 to v2.

## Why

These conflict markers would cause CI workflow parse failures. Resolved by accepting the v2 upgrade (the newer version dependabot was suggesting).

## Pre-merge checklist
- [x] `pnpm format` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — all passing