### PR TITLE
ci: split lint and format:check into separate CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +23,20 @@ jobs:
 
       - run: pnpm install
       - run: pnpm format:check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install
       - run: pnpm lint
 
   test:


### PR DESCRIPTION
Closes #193

**Problem:** The `lint` job ran both `pnpm format:check` (Prettier) and `pnpm lint` (ESLint). When Prettier failed, the PR check showed **lint: fail**, which was misleading.

**Fix:** Split into two distinct jobs:
- **`format`** — runs `pnpm format:check` (Prettier)
- **`lint`** — runs `pnpm lint` (ESLint)

Both appear as separate checks on PRs. No functional change to what gets checked.