### PR TITLE
fix(ci): make release back-merge conflict-resilient

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,5 +101,12 @@ jobs:
         run: |
           git checkout dev
           git pull origin dev
-          git merge main --no-edit -m "chore: back-merge main after release [skip ci]"
+          # -X theirs: main's graduated versions win over dev's stale alphas
+          git merge main -X theirs --no-edit -m "chore: back-merge main after release [skip ci]"
+          # Re-enter prerelease mode so the next dev push produces alphas
+          if [ ! -f ".changeset/pre.json" ]; then
+            pnpm changeset pre enter alpha
+            git add .changeset/pre.json
+            git commit -m "chore: re-enter prerelease mode after back-merge [skip ci]"
+          fi
           git push origin dev


### PR DESCRIPTION
The back-merge step in release.yml used a naive 'git merge main' with no conflict strategy. When dev had newer alpha version bumps (which it always does), the merge silently failed, leaving dev permanently diverged from main on package versions and CHANGELOGs.

Changes:
- Add '-X theirs' so main's graduated versions win over stale alphas
- Re-enter changeset prerelease mode after back-merge so dev continues publishing alpha releases on the next push