### PR TITLE
fix(ci): resolve port conflict in performance benchmark workflow

### DIFF
--- a/.changeset/fix-perf-benchmark-port-conflict.md
+++ b/.changeset/fix-perf-benchmark-port-conflict.md
@@ -1,0 +1,14 @@
+---
+---
+
+fix(ci): resolve port conflict in performance benchmark workflow
+
+The performance workflow was manually starting `next start` on port 3000
+before running Playwright benchmarks. Since the Playwright config also
+defines a `webServer` that starts on port 3000 (with `reuseExistingServer:
+false` in CI), every benchmark step failed with a port conflict.
+
+The fix removes the redundant manual build/start steps and uses
+`PERF_NO_SERVER` to disable Playwright's webServer for benchmarks that
+don't need a running server (build-time, bundle-size). The runtime-vitals
+benchmark now uses Playwright's built-in webServer lifecycle as intended.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -44,25 +44,18 @@ jobs:
       - name: 🔗 Re-link bins after build
         run: pnpm install
 
-      - name: 🔧 Build example app
-        run: |
-          pnpm --filter stackwright-example-app exec stackwright-prebuild
-          pnpm --filter stackwright-example-app exec next build
-
-      - name: 🚀 Start example app
-        run: |
-          pnpm --filter stackwright-example-app exec next start &
-          sleep 10
-          curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000
-
       - name: ⚡ Run build time benchmarks
         id: build-time
+        env:
+          PERF_NO_SERVER: '1'
         run: |
           pnpm --filter @stackwright/e2e exec playwright test tests/performance/build-time.bench.ts --reporter=list
         continue-on-error: true
 
       - name: 📦 Run bundle size benchmarks
         id: bundle-size
+        env:
+          PERF_NO_SERVER: '1'
         run: |
           pnpm --filter @stackwright/e2e exec playwright test tests/performance/bundle-size.bench.ts --reporter=list
         continue-on-error: true

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -83,11 +83,13 @@ export default defineConfig({
       testIgnore: ['**/*.visual.spec.ts', '**/*.bench.ts'],
     },
   ],
-  webServer: {
-    command: `pnpm --filter stackwright-example-app exec stackwright-prebuild && pnpm --filter stackwright-example-app exec next build && pnpm --filter stackwright-example-app exec next start`,
-    cwd: path.resolve(__dirname, '../..'),
-    port: 3000,
-    timeout: 180_000,
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: process.env.PERF_NO_SERVER
+    ? undefined
+    : {
+        command: `pnpm --filter stackwright-example-app exec stackwright-prebuild && pnpm --filter stackwright-example-app exec next build && pnpm --filter stackwright-example-app exec next start`,
+        cwd: path.resolve(__dirname, '../..'),
+        port: 3000,
+        timeout: 180_000,
+        reuseExistingServer: !process.env.CI,
+      },
 });


### PR DESCRIPTION
## Problem

The Performance Benchmarks CI workflow was failing with:

```
Error: http://localhost:3000 is already used, make sure that nothing is running
on the port/url or set reuseExistingServer:true in config.webServer.
```

### Root Cause

The workflow had a double-start problem:

1. **Workflow** manually ran `next build` + `next start` on port 3000
2. **Playwright's `webServer` config** also tried to build & start on port 3000
3. In CI, `reuseExistingServer: !process.env.CI` evaluates to `false`, so Playwright refused to reuse the existing server → 💥 port conflict

There was also a deeper design flaw: the `build-time.bench.ts` benchmark **deletes `.next/`** and rebuilds from scratch, which would crash any running `next start` that was serving from that directory.

## Fix

- **Remove** the redundant manual build/start steps from `performance.yml` (DRY — Playwright already handles this)
- **Add `PERF_NO_SERVER`** env var for build-time and bundle-size benchmarks (they don't need a running server — they just run shell commands and analyze build output)
- **Runtime-vitals** benchmark now uses Playwright's built-in `webServer` lifecycle as intended

## Changes

| File | What |
|------|------|
| `.github/workflows/performance.yml` | Remove manual build/start, add `PERF_NO_SERVER` to non-server benchmarks |
| `packages/e2e/playwright.config.ts` | Skip `webServer` when `PERF_NO_SERVER` is set |
