### PR TITLE
fix(ci): repair release and prerelease pipeline bugs

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   prerelease:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore: bump prerelease versions [skip ci]') }}
     steps:
       - name: Generate PerAsperaCI token
         id: app-token
@@ -66,6 +66,6 @@ jobs:
           git push origin dev
 
       - name: Publish prereleases with tag 'alpha'
-        run: pnpm publish -r --provenance --access public --tag alpha
+        run: pnpm publish -r --provenance --access public --tag alpha --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    # Use startsWith (not contains) to check ONLY the commit title for [skip ci].
+    # Squash merges embed individual commit messages in the body, and automated
+    # commits (prerelease bumps, etc.) include [skip ci] — which would incorrectly
+    # suppress the release workflow if we used contains() on the full body.
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore: version packages for release [skip ci]') }}
     steps:
       - name: Generate PerAsperaCI token
         id: app-token


### PR DESCRIPTION
## Problem

The release infrastructure has three bugs that have been silently broken for weeks:

### Bug 1: Prerelease publish does nothing 🤫

`pnpm publish` on the `dev` branch prompts:
```
? You're on branch "dev" but your "publish-branch" is set to "master|main".
  Do you want to continue? (y/N) ‣ false
```
In CI (no TTY), it defaults to `false` and exits with code 0 — "success" but nothing publishes.

**Fix:** Add `--no-git-checks` (matching what `release.yml` already uses).

### Bug 2: Release workflow never triggers on squash merges 💀

The workflow uses `contains(github.event.head_commit.message, '[skip ci]')`. Squash merges embed all individual commit messages in the body, including:
```
* chore: bump prerelease versions [skip ci]
* chore: update visual regression baselines [skip ci]
```
`contains()` matches these buried strings, so the release workflow is skipped on every squash merge.

**Fix:** Use `startsWith()` to match only the specific CI commit title, not arbitrary body content.

### Bug 3: Prerelease has same trigger issue

Same `contains()` vs `startsWith()` problem.

## Changes

| File | Fix |
|------|-----|
| `prerelease.yml` | Add `--no-git-checks` to publish command |
| `prerelease.yml` | `contains()` → `startsWith()` for skip-ci check |
| `release.yml` | `contains()` → `startsWith()` for skip-ci check |

## Note on back-merge

The back-merge step in `release.yml` was previously blocked by the dev branch ruleset requiring linear history. That ruleset was split and relaxed in a separate change (dev no longer requires linear history), so the back-merge will now succeed.
