### PR TITLE
feat(core): page-level navSidebar override for dashboards and docs

### DIFF
--- a/.changeset/nav-sidebar-override.md
+++ b/.changeset/nav-sidebar-override.md
@@ -1,0 +1,16 @@
+---
+"@stackwright/core": minor
+"@stackwright/types": minor
+---
+
+feat(core): add page-level `navSidebar` override in `content.yml`
+
+Pages can now override the site-wide sidebar defined in `stackwright.yml` using the `navSidebar` field. This enables:
+
+- Dashboard pages to hide the sidebar (`navSidebar: null`) for full-width content
+- Documentation chapters to show page-specific navigation in the sidebar
+- Page Otter to customize sidebar behavior without editing the theme
+
+The resolution order is: page `navSidebar` > site `sidebar` (from Theme Otter) > no sidebar.
+
+Docs and AGENTS.md updated with examples and Otter responsibility notes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,51 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md#troubleshooting) for common issues and d
   - [Zod Documentation](https://zod.dev/)
 - **Monorepo Management**
   - [PNPM Workspaces](https://pnpm.io/workspaces)
+### Page-Level Sidebar Override (`navSidebar`)
+
+Pages can override the site-wide sidebar defined in `stackwright.yml` using the `navSidebar` field in their `content.yml`.
+
+**Resolution order (highest wins):**
+1. Page-level `navSidebar` in `content.yml` (explicit override)
+2. Site-level `sidebar` in `stackwright.yml` (default from Theme Otter)
+3. No sidebar
+
+**Use cases:**
+- Dashboard pages: `navSidebar: null` to maximize content width
+- Documentation chapters: different sidebar with section-specific navigation
+- Landing pages: inherit site sidebar from theme
+
+**YAML examples:**
+
+```yaml
+# Hide sidebar on this page (full-width content)
+content:
+  navSidebar: null
+  content_items:
+    - type: main
+      label: "dashboard"
+      heading:
+        text: "Live Dashboard"
+        textSize: "h1"
+
+# Override sidebar navigation for this page
+content:
+  navSidebar:
+    navigation:
+      - label: "Chapter 1"
+        href: "/docs/chapter-1"
+      - label: "Chapter 2"
+        href: "/docs/chapter-2"
+    collapsed: false
+  content_items:
+    - type: text_block
+      label: "chapter-2-content"
+      textBlocks:
+        - text: "Chapter 2 content here..."
+          textSize: "body1"
+```
+
+**Otter responsibilities:**
+- **Theme Otter** sets the site-wide sidebar defaults in `stackwright.yml`
+- **Page Otter** can add `navSidebar` overrides in any page's `content.yml`
+- If Theme Otter chose a sidebar theme, Page Otter inherits it by default (no need to repeat)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@ This agent is the proof point for the platform's thesis: that non-technical peop
 
 ## Framework Direction
 
-Stackwright ships 15 content types (carousel, main, tabbed_content, media, timeline, icon_grid, code_block, feature_list, testimonial_grid, faq, pricing_table, alert, contact_form_stub, grid, collection_list). Dark mode, SEO metadata, cookie persistence, and responsive design are first-class.
+Stackwright ships 18 content types (carousel, main, tabbed_content, media, video, timeline, icon_grid, code_block, feature_list, testimonial_grid, faq, pricing_table, alert, contact_form_stub, grid, collection_list, text_block, map). Dark mode, SEO metadata, cookie persistence, and responsive design are first-class.
 
 **Next framework priorities** are tracked as GitHub Issues. Themes from PHILOSOPHY.md that shape prioritization:
 

--- a/packages/core/src/components/structural/DefaultPageLayout.tsx
+++ b/packages/core/src/components/structural/DefaultPageLayout.tsx
@@ -1,26 +1,67 @@
 import React from 'react';
-import { PageContent } from '@stackwright/types';
+import { PageContent, SiteConfig } from '@stackwright/types';
 import { renderContent } from '../../utils/contentRenderer';
 import { useSafeTheme } from '../../hooks/useSafeTheme';
 import { useSiteConfig } from '../../hooks/useSiteConfig';
 import NavSidebar from './NavSidebar';
 
 // This is now a simple wrapper - consider deprecating in favor of PageLayout
+
+/**
+ * Reuses the same sidebar resolution logic as PageLayout so that
+ * DefaultPageLayout consumers also get page-level navSidebar overrides.
+ */
+function resolveSidebarConfig(
+  pageSidebar: PageContent['content']['navSidebar'],
+  siteSidebar: SiteConfig['sidebar']
+): SiteConfig['sidebar'] | undefined {
+  if (pageSidebar === null) return undefined;
+  if (pageSidebar === undefined) return siteSidebar;
+
+  if (siteSidebar) {
+    return {
+      navigation: pageSidebar.navigation ?? siteSidebar.navigation,
+      collapsed: pageSidebar.collapsed ?? siteSidebar.collapsed,
+      width: pageSidebar.width ?? siteSidebar.width,
+      mobileBreakpoint: pageSidebar.mobileBreakpoint ?? siteSidebar.mobileBreakpoint,
+      backgroundColor: pageSidebar.backgroundColor ?? siteSidebar.backgroundColor,
+      textColor: pageSidebar.textColor ?? siteSidebar.textColor,
+    };
+  }
+
+  if (pageSidebar.navigation) {
+    return {
+      navigation: pageSidebar.navigation,
+      collapsed: pageSidebar.collapsed ?? false,
+      width: pageSidebar.width ?? 240,
+      mobileBreakpoint: pageSidebar.mobileBreakpoint ?? 768,
+      backgroundColor: pageSidebar.backgroundColor,
+      textColor: pageSidebar.textColor,
+    };
+  }
+
+  return undefined;
+}
+
 export default function DefaultPageLayout(pageContent: PageContent) {
   const theme = useSafeTheme();
   const siteConfig = useSiteConfig();
-  const sidebarConfig = siteConfig?.sidebar;
+
+  const resolvedSidebar = resolveSidebarConfig(
+    pageContent?.content?.navSidebar,
+    siteConfig?.sidebar
+  );
 
   return (
     <div style={{ display: 'flex', minHeight: '100vh' }}>
-      {sidebarConfig && (
+      {resolvedSidebar && (
         <NavSidebar
-          navigationItems={sidebarConfig.navigation}
-          collapsed={sidebarConfig.collapsed}
-          width={sidebarConfig.width}
-          mobileBreakpoint={sidebarConfig.mobileBreakpoint}
-          backgroundColor={sidebarConfig.backgroundColor}
-          textColor={sidebarConfig.textColor}
+          navigationItems={resolvedSidebar.navigation}
+          collapsed={resolvedSidebar.collapsed}
+          width={resolvedSidebar.width}
+          mobileBreakpoint={resolvedSidebar.mobileBreakpoint}
+          backgroundColor={resolvedSidebar.backgroundColor}
+          textColor={resolvedSidebar.textColor}
         />
       )}
       <main

--- a/packages/core/src/components/structural/PageLayout.tsx
+++ b/packages/core/src/components/structural/PageLayout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import TopAppBar from './TopAppBar';
-import { PageContent } from '@stackwright/types';
-import { SiteConfig } from '@stackwright/types';
+import { PageContent, SiteConfig, PageSidebar } from '@stackwright/types';
 import BottomAppBar from './BottomAppBar';
 import NavSidebar from './NavSidebar';
 import { SearchModal } from './SearchModal';
@@ -14,13 +13,69 @@ interface PageLayoutProps {
   siteConfig?: SiteConfig;
 }
 
+/**
+ * Resolves the effective sidebar config for a page.
+ *
+ * Resolution order (highest wins):
+ *  1. Page-level `navSidebar` in content.yml (explicit override)
+ *  2. Site-level `sidebar` in stackwright.yml (default)
+ *  3. undefined (no sidebar)
+ *
+ * Special case: `navSidebar: null` in page content always hides the sidebar,
+ * even when the site config has a sidebar. This lets dashboard / full-bleed
+ * pages opt out without removing the sidebar from the theme.
+ */
+function resolveSidebarConfig(
+  pageSidebar: PageSidebar,
+  siteSidebar: SiteConfig['sidebar']
+): SiteConfig['sidebar'] | undefined {
+  // null means "hide sidebar on this page" — explicit override wins
+  if (pageSidebar === null) {
+    return undefined;
+  }
+
+  // undefined means "use site config" (no override)
+  if (pageSidebar === undefined) {
+    return siteSidebar;
+  }
+
+  // Partial override — merge page values over site defaults
+  if (siteSidebar) {
+    return {
+      navigation: pageSidebar.navigation ?? siteSidebar.navigation,
+      collapsed: pageSidebar.collapsed ?? siteSidebar.collapsed,
+      width: pageSidebar.width ?? siteSidebar.width,
+      mobileBreakpoint: pageSidebar.mobileBreakpoint ?? siteSidebar.mobileBreakpoint,
+      backgroundColor: pageSidebar.backgroundColor ?? siteSidebar.backgroundColor,
+      textColor: pageSidebar.textColor ?? siteSidebar.textColor,
+    };
+  }
+
+  // Site has no sidebar, but page provides values — build a sidebar from page config
+  if (pageSidebar.navigation) {
+    return {
+      navigation: pageSidebar.navigation,
+      collapsed: pageSidebar.collapsed ?? false,
+      width: pageSidebar.width ?? 240,
+      mobileBreakpoint: pageSidebar.mobileBreakpoint ?? 768,
+      backgroundColor: pageSidebar.backgroundColor,
+      textColor: pageSidebar.textColor,
+    };
+  }
+
+  return undefined;
+}
+
 export default function PageLayout({ pageContent, siteConfig }: PageLayoutProps) {
   const theme = useSafeTheme();
-
   const config = siteConfig || defaultSiteConfig;
-
   const backgroundColor = theme.colors.background;
-  const hasSidebar = !!config.sidebar;
+
+  // Resolve sidebar: page-level override > site-level default
+  const resolvedSidebar = resolveSidebarConfig(
+    pageContent.content.navSidebar,
+    config.sidebar
+  );
 
   return (
     <div
@@ -28,7 +83,7 @@ export default function PageLayout({ pageContent, siteConfig }: PageLayoutProps)
         display: 'flex',
         flexDirection: 'column',
         minHeight: '100vh',
-        backgroundColor: backgroundColor,
+        backgroundColor,
         color: theme.colors.text,
       }}
     >
@@ -41,29 +96,19 @@ export default function PageLayout({ pageContent, siteConfig }: PageLayoutProps)
         colorModeToggle={config.appBar.colorModeToggle}
       />
 
-      <div
-        style={{
-          display: 'flex',
-          flex: 1,
-        }}
-      >
-        {hasSidebar && (
+      <div style={{ display: 'flex', flex: 1 }}>
+        {resolvedSidebar && (
           <NavSidebar
-            navigationItems={config.sidebar!.navigation}
-            collapsed={config.sidebar!.collapsed}
-            width={config.sidebar!.width}
-            mobileBreakpoint={config.sidebar!.mobileBreakpoint}
-            backgroundColor={config.sidebar!.backgroundColor}
-            textColor={config.sidebar!.textColor}
+            navigationItems={resolvedSidebar.navigation}
+            collapsed={resolvedSidebar.collapsed}
+            width={resolvedSidebar.width}
+            mobileBreakpoint={resolvedSidebar.mobileBreakpoint}
+            backgroundColor={resolvedSidebar.backgroundColor}
+            textColor={resolvedSidebar.textColor}
           />
         )}
 
-        <main
-          style={{
-            flex: 1,
-            backgroundColor: backgroundColor,
-          }}
-        >
+        <main style={{ flex: 1, backgroundColor }}>
           {renderContent(pageContent)}
         </main>
       </div>

--- a/packages/core/test/components/nav-sidebar.test.tsx
+++ b/packages/core/test/components/nav-sidebar.test.tsx
@@ -412,7 +412,7 @@ describe('NavSidebar', () => {
       const TestDefaultLayout = () => {
         return (
           <SiteConfigProvider value={mockSiteConfig}>
-            <DefaultPageLayout content_items={[]} />
+            <DefaultPageLayout {...{ content: { content_items: [] } }} />
           </SiteConfigProvider>
         );
       };
@@ -438,7 +438,7 @@ describe('NavSidebar', () => {
       const TestDefaultLayout = () => {
         return (
           <SiteConfigProvider value={mockSiteConfig}>
-            <DefaultPageLayout content_items={[]} />
+            <DefaultPageLayout {...{ content: { content_items: [] } }} />
           </SiteConfigProvider>
         );
       };

--- a/packages/types/schemas/content-schema.json
+++ b/packages/types/schemas/content-schema.json
@@ -116,6 +116,40 @@
         },
         "list_icon": {
           "type": "string"
+        },
+        "navSidebar": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "navigation": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/__schema18"
+                  }
+                },
+                "collapsed": {
+                  "type": "boolean"
+                },
+                "width": {
+                  "type": "number"
+                },
+                "mobileBreakpoint": {
+                  "type": "number"
+                },
+                "backgroundColor": {
+                  "type": "string"
+                },
+                "textColor": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [

--- a/packages/types/src/types/layout.ts
+++ b/packages/types/src/types/layout.ts
@@ -1,7 +1,45 @@
 import { z } from 'zod';
 import { baseContentSchema, buttonContentSchema } from './base';
-import { appBarContentSchema } from './navigation';
+import { appBarContentSchema, navigationItemSchema } from './navigation';
 import { contentItemSchema } from './content';
+
+/**
+ * Page-level sidebar override.
+ *
+ * - Omit the field entirely  → fall back to site config (stackwright.yml sidebar)
+ * - Set to null              → hide sidebar on this page
+ * - Set to an object         → use these sidebar config values for this page
+ *
+ * Use cases:
+ * - A dashboard page hides the nav sidebar to maximize content width
+ * - A documentation page shows a different sidebar with chapter navigation
+ * - A landing page inherits the site sidebar
+ *
+ * The Theme Otter sets the site-wide sidebar defaults in stackwright.yml.
+ * Page Otter can override per-page for dashboards, docs chapters, etc.
+ */
+export const pageSidebarSchema = z
+  .object({
+    /**
+     * Override the navigation items shown in the sidebar.
+     * Falls back to site sidebar navigation if omitted.
+     */
+    navigation: z.array(navigationItemSchema).optional(),
+    /** Override whether the sidebar starts collapsed. */
+    collapsed: z.boolean().optional(),
+    /** Override the sidebar width in pixels. */
+    width: z.number().optional(),
+    /** Override the mobile breakpoint in pixels. */
+    mobileBreakpoint: z.number().optional(),
+    /** Override the sidebar background color. */
+    backgroundColor: z.string().optional(),
+    /** Override the sidebar text color. */
+    textColor: z.string().optional(),
+  })
+  .nullable()
+  .optional();
+
+export type PageSidebar = z.infer<typeof pageSidebarSchema>;
 
 export const footerContentSchema = baseContentSchema.extend({
   copyright: z.string(),
@@ -25,6 +63,18 @@ export const pageContentSchema = z.object({
     footer: footerContentSchema.optional(),
     content_items: z.array(contentItemSchema),
     list_icon: z.string().optional(),
+    /**
+     * Page-level sidebar override.
+     *
+     * - Omit entirely → use site config sidebar (stackwright.yml sidebar)
+     * - Set to null   → hide sidebar on this page
+     * - Set to object → use these values for the sidebar, falling back to
+     *                   site config for any unspecified fields
+     *
+     * The Theme Otter sets the site-wide sidebar in stackwright.yml.
+     * Page Otter can override per-page for dashboards, docs chapters, etc.
+     */
+    navSidebar: pageSidebarSchema,
   }),
 });
 


### PR DESCRIPTION
## Summary

Pages can now override the site-wide sidebar defined in `stackwright.yml` using the `navSidebar` field in their `content.yml`.

### Resolution Order
1. **Page-level** `navSidebar` in `content.yml` (explicit override)
2. **Site-level** `sidebar` in `stackwright.yml` (default from Theme Otter)
3. **None** (no sidebar)

### What Changed
- **Schema** (`packages/types/src/types/layout.ts`): Added `pageSidebarSchema` and `navSidebar` field to `pageContentSchema`
- **Layout components** (`PageLayout.tsx`, `DefaultPageLayout.tsx`): Added `resolveSidebarConfig()` with merge logic
- **Tests**: Fixed 2 existing tests that were passing malformed data
- **Docs**: Added `navSidebar` section to `AGENTS.md` with YAML examples
- **ROADMAP.md**: Fixed stale "15 content types" → "18 content types"

### YAML Examples
```yaml
# Hide sidebar on this page (full-width dashboard)
content:
  navSidebar: null
  content_items:
    - type: main
      label: "dashboard"

# Override sidebar navigation for this page
content:
  navSidebar:
    navigation:
      - label: "Chapter 1"
        href: "/docs/chapter-1"
  content_items:
    - type: text_block
      label: "chapter-1-content"
```

### Otter Responsibilities
- **Theme Otter**: Sets site-wide sidebar defaults in `stackwright.yml`
- **Page Otter**: Can override per-page without touching the theme

## Reviewers Needed

| Reviewer | Area | Status |
|----------|------|--------|
| @Per-Aspera-LLC/security-auditor | Security review (null safety, XSS) | ⏳ |
| @Per-Aspera-LLC/code-puppy | TypeScript types, schema | ⏳ |
| @Per-Aspera-LLC/qa-kitten | QA (tests, edge cases) | ⏳ |

## Checklist
- [x] TypeScript types compile cleanly
- [x] Unit tests pass (286 tests)
- [x] Schema JSON regenerated (`pnpm generate-schemas`)
- [x] Changelog entry created

---
cc @planning-agent @Charles