### PR TITLE
fix: resolve missing icons and architecture page layout issues

### DIFF
--- a/.changeset/fix-icons-architecture-codeblock.md
+++ b/.changeset/fix-icons-architecture-codeblock.md
@@ -1,0 +1,18 @@
+---
+"@stackwright/icons": patch
+"@stackwright/core": patch
+---
+
+Fix missing Lucide icons (Code2, Layout) and improve CodeBlock rendering for ASCII art diagrams
+
+### Icon Registry Fixes
+- **Code2 icon**: Added direct import to lucideAllIcons.ts (was missing from barrel export)
+- **Layout icon**: Added direct import to lucideAllIcons.ts (was missing from barrel export)
+
+### CodeBlock Improvements  
+- Better monospace font stack for proper ASCII art alignment
+- Added font-variant-ligatures: none to prevent character transformation issues
+
+### Architecture Page Fixes
+- Replaced problematic YAML/JSON code blocks with tabbed_content component
+- Fixed overflow issues caused by ASCII art alignment problems

--- a/examples/stackwright-docs/pages/architecture/content.yml
+++ b/examples/stackwright-docs/pages/architecture/content.yml
@@ -1,4 +1,35 @@
 content:
+  navSidebar:
+    navigation:
+      - label: "📖 Documentation"
+        href: /getting-started
+        children:
+          - label: "🚀 Getting Started"
+            href: /getting-started
+          - label: "📦 Content Types"
+            href: /content-types
+          - label: "🏗️ Architecture"
+            href: /architecture
+          - label: "⌨️ CLI Reference"
+            href: /cli
+      - label: "🤖 AI Agents"
+        href: /otter-raft
+        children:
+          - label: "🤖 Otter Raft"
+            href: /otter-raft
+          - label: "🔐 Pro"
+            href: /pro
+      - label: "📜 Legal"
+        href: /acknowledgements
+        children:
+          - label: "🙏 Acknowledgements"
+            href: /acknowledgements
+          - label: "🔒 Privacy Policy"
+            href: /privacy-policy
+          - label: "📝 Terms of Service"
+            href: /terms-of-service
+      - label: "🧪 Showcase"
+        href: /showcase
   meta:
     title: Architecture | Stackwright
     description: How Stackwright compiles YAML into production Next.js apps. Technical deep-dive.
@@ -51,22 +82,57 @@ content:
     - text: 'The prebuild step compiles your YAML into static JSON. Here''s what that looks like:'
       textSize: body1
     background: background
-  - type: code_block
-    label: yaml-input
-    language: yaml
-    lineNumbers: true
-    code: 'content:\n  content_items:\n    - type: main\n      label: hero\n      heading:\n        text: "Hello, World!"\n        textSize: h1\n      textBlocks:\n        - text: "Welcome to my site."\n          textSize: body1\n      buttons:\n        - text: "Get Started"\n          href: /getting-started\n          variant: contained'
-  - type: text_block
-    label: arrow-1
-    textBlocks:
-    - text: ⬇️ prebuild transforms to
-      textSize: caption
-    background: background
-  - type: code_block
-    label: json-output
-    language: json
-    lineNumbers: true
-    code: '{\n  "content": {\n    "content_items": [{\n      "type": "main",\n      "label": "hero",\n      "heading": {\n        "text": "Hello, World!",\n        "textSize": "h1"\n      },\n      "textBlocks": [{\n        "text": "Welcome to my site.",\n        "textSize": "body1"\n      }],\n      "buttons": [{\n        "text": "Get Started",\n        "href": "/getting-started",\n        "variant": "contained"\n      }]\n    }]\n  }\n}'
+  - type: tabbed_content
+    label: yaml-json-tabs
+    heading:
+      text: YAML → JSON
+      textSize: h3
+    background: surface
+    tabs:
+      - label: YAML Input
+        type: code_block
+        language: yaml
+        lineNumbers: true
+        code: |
+          content:
+            content_items:
+              - type: main
+                label: hero
+                heading:
+                  text: "Hello, World!"
+                textBlocks:
+                  - text: "Welcome to my site."
+                    textSize: body1
+                buttons:
+                  - text: "Get Started"
+                    href: /getting-started
+                    variant: contained
+      - label: JSON Output
+        type: code_block
+        language: json
+        lineNumbers: true
+        code: |
+          {
+            "content": {
+              "content_items": [{
+                "type": "main",
+                "label": "hero",
+                "heading": {
+                  "text": "Hello, World!",
+                  "textSize": "h1"
+                },
+                "textBlocks": [{
+                  "text": "Welcome to my site.",
+                  "textSize": "body1"
+                }],
+                "buttons": [{
+                  "text": "Get Started",
+                  "href": "/getting-started",
+                  "variant": "contained"
+                }]
+              }]
+            }
+          }
   - type: alert
     label: no-runtime-fs
     variant: info

--- a/packages/core/src/components/DynamicPage.tsx
+++ b/packages/core/src/components/DynamicPage.tsx
@@ -223,7 +223,6 @@ function DynamicPageInner({
         style={{
           minHeight: '100vh',
           position: 'relative',
-          overflow: 'hidden',
           fontFamily: theme.typography?.fontFamily?.primary || 'sans-serif',
           ...backgroundImageStyles,
           animation: getDriftFloatAnimation(),

--- a/packages/core/src/components/base/CodeBlock.tsx
+++ b/packages/core/src/components/base/CodeBlock.tsx
@@ -42,7 +42,8 @@ export function CodeBlock({ code, language, lineNumbers = false, background }: C
         style={{
           backgroundColor: theme.colors.surface,
           borderRadius: '4px',
-          overflow: 'auto',
+          overflow: 'hidden',
+          maxWidth: '100%',
           border: `1px solid ${theme.colors.textSecondary}22`,
         }}
       >
@@ -68,15 +69,19 @@ export function CodeBlock({ code, language, lineNumbers = false, background }: C
           style={{
             margin: 0,
             padding: theme.spacing.md,
-            overflow: 'auto',
-            fontFamily: 'monospace',
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            maxWidth: '100%',
+            fontFamily: "'Consolas', 'Monaco', 'Courier New', monospace",
             fontSize: '0.875rem',
             lineHeight: 1.6,
             color: theme.colors.text,
+            whiteSpace: 'pre',
+            fontVariantLigatures: 'none',
           }}
         >
           {tokenLines.map((lineTokens, i) => (
-            <span key={i} style={{ display: 'flex', gap: theme.spacing.md }}>
+            <span key={i} style={{ display: 'block' }}>
               {lineNumbers && (
                 <span
                   style={{
@@ -84,7 +89,8 @@ export function CodeBlock({ code, language, lineNumbers = false, background }: C
                     minWidth: '2ch',
                     textAlign: 'right',
                     color: theme.colors.textSecondary,
-                    flexShrink: 0,
+                    display: 'inline-block',
+                    marginRight: theme.spacing.md,
                   }}
                 >
                   {i + 1}

--- a/packages/icons/src/presets/lucideAllIcons.ts
+++ b/packages/icons/src/presets/lucideAllIcons.ts
@@ -2,7 +2,7 @@
 // Imports the complete icon library (~1,500+ icons) via Lucide's barrel export.
 // For a lighter alternative with ~40 curated icons, use lucideIcons.ts instead.
 
-import { icons } from 'lucide-react';
+import { icons, Code2, Layout } from 'lucide-react';
 import { registerStackwrightIcons } from '../registry/iconRegistry';
 
 // Legacy MUI icon name aliases — ensures existing YAML content continues to work.
@@ -29,9 +29,17 @@ const lucideRenamedAliases: Record<string, React.ComponentType<any>> = {
   AlertTriangle: icons.TriangleAlert,
 };
 
+// Direct export icons — these exist in lucide-react but are NOT in the icons barrel export.
+// Code2 is exported directly but missing from the icons object type.
+const lucideDirectExports: Record<string, React.ComponentType<any>> = {
+  Code2,
+  Layout,
+};
+
 export const lucideAllIconsPreset: Record<string, React.ComponentType<any>> = {
   ...(icons as unknown as Record<string, React.ComponentType<any>>),
   ...lucideRenamedAliases,
+  ...lucideDirectExports,
   ...legacyMuiAliases,
 };
 


### PR DESCRIPTION
## Summary

Fixed multiple issues in the documentation site and icon registry:

### Icon Registry Fixes
- **Code2 icon**: Added direct import to lucideAllIcons.ts (was missing from barrel export)
- **Layout icon**: Added direct import to lucideAllIcons.ts (was missing from barrel export)

### CodeBlock Improvements  
- Better monospace font stack for proper ASCII art alignment
- Added font-variant-ligatures: none to prevent character transformation issues

### Architecture Page Fixes
- Replaced problematic YAML/JSON code blocks with tabbed_content component
- Fixed missing heading field in tabbed_content
- Fixed tab structure to use direct content items

### Related
- Resolves layout overflow issues caused by ASCII art alignment problems

## Testing
- All 684 unit tests pass
- Architecture page renders correctly
- No console errors for missing icons