### PR TITLE
fix(maplibre): remove invalid attributionControl prop and verify lockfile

### DIFF
--- a/.changeset/fix-maplibre-lockfile.md
+++ b/.changeset/fix-maplibre-lockfile.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/maplibre": patch
+---
+
+Fix TypeScript build error and verify package is properly registered in lockfile

--- a/packages/maplibre/src/MapLibreProvider.tsx
+++ b/packages/maplibre/src/MapLibreProvider.tsx
@@ -89,7 +89,6 @@ export const MapLibreProvider: React.FC<MapProviderProps> = ({
         }}
         style={{ width: '100%', height: '100%', borderRadius: '8px' }}
         mapStyle={mapStyle}
-        attributionControl={true}
       >
         {/* Navigation controls (zoom, rotate) */}
         <NavigationControl position="top-right" />


### PR DESCRIPTION
## Summary

This PR fixes a TypeScript build error in `@stackwright/maplibre` and verifies the package is properly registered in the lockfile.

### Changes
- **Removed invalid prop**: `attributionControl={true}` caused a TypeScript error because the type expects `AttributionControlOptions | false | undefined`, not `boolean`
- **Lockfile verification**: Confirmed `@stackwright/maplibre` is properly registered in `pnpm-lock.yaml`

### Build Status
- ✅ CJS build: `dist/index.js`
- ✅ ESM build: `dist/index.mjs`
- ✅ DTS build: `dist/index.d.ts`
- ✅ Tests: 3/3 passed

### Testing
Build and tests verified locally. This PR ensures the `sync-docs.yml` workflow won't fail due to lockfile issues.

---

Closes: (leave blank or reference any related issue)