### PR TITLE
fix(types): add image dimension validation

### DIFF
--- a/.changeset/add-image-dimension-validation.md
+++ b/.changeset/add-image-dimension-validation.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/types": patch
+---
+
+Add Zod `.refine()` validation for image dimensions. BREAKING: Images must have both height+width OR height+aspect_ratio. Fix content.yml with explicit dimensions.

--- a/examples/stackwright-docs/pages/content.yml
+++ b/examples/stackwright-docs/pages/content.yml
@@ -2,7 +2,7 @@ content:
   meta:
     title: "Stackwright — YAML is the syntax. The schema is the safety net. AI writes the code."
     description: "From API spec to working Next.js app in hours. Stackwright is a typed DSL where AI agents write YAML, the schema enforces safety, and the output is a production-ready React app you own."
-  
+
 
   content_items:
     # 1. Hero Section
@@ -24,6 +24,14 @@ content:
           textSize: button
           variant: outlined
           href: https://github.com/Per-Aspera-LLC/stackwright
+      media:
+        type: image
+        src: ./stackwright-digital.png
+        alt: Stackwright Logo
+        label: hero-logo
+        height: 280
+        width: 280
+      graphic_position: right
       background: background
       color: text
 

--- a/examples/stackwright-docs/pages/otter-raft/content.yml
+++ b/examples/stackwright-docs/pages/otter-raft/content.yml
@@ -24,7 +24,7 @@ content:
     # ─────────────────────────────────────────────────────────
     - type: video
       label: demo-video
-      src: "/videos/otter-raft-demo.mp4"
+      src: "./otter-raft-demo.mp4"
       alt: "Watch the Otter Raft build the stackwright-docs site from conversation"
       height: 480
       width: "100%"
@@ -39,7 +39,7 @@ content:
       label: video-note
       variant: note
       title: "🎬 Watch the Otters Build Their Own Docs"
-      body: "The video above shows the Otter Raft building the stackwright-docs site from scratch. Brand discovery → Theme design → Page generation → Deploy. No YAML expertise required."
+      body: "The video above shows the Otter Raft working on the stackwright-docs site, which was built from scratch. Brand discovery → Theme design → Page generation → Deploy. No YAML expertise required."
       background: surface
 
     # ─────────────────────────────────────────────────────────
@@ -106,17 +106,17 @@ content:
               lineNumbers: false
               code: |
                 # BRAND_BRIEF.md (Brand Otter)
-                
+
                 ## Voice
                 Professional, authoritative
-                
+
                 ## Colors
                 Primary: Navy blue (#1a365d)
                 Accent: Gold (#d4af37)
-                
+
                 ## Personality
                 Confident, precise
-                
+
                 ## Target Audience
                 Enterprise, developers
         - width: 33
@@ -127,7 +127,7 @@ content:
               lineNumbers: false
               code: |
                 # stackwright.yml (Theme Otter)
-                
+
                 customTheme:
                   colors:
                     primary: "#1a365d"
@@ -144,7 +144,7 @@ content:
               lineNumbers: false
               code: |
                 # pages/index.yml (Page Otter)
-                
+
                 content:
                   content_items:
                     - type: main
@@ -220,14 +220,14 @@ content:
         # Scaffold a new project (includes Otter Raft)
         npx launch-stackwright my-site
         cd my-site
-        
+
         # The Otter Raft configs are in:
         .stackwright/otters/
         ├── stackwright-brand-otter.json
         ├── stackwright-theme-otter.json
         ├── stackwright-page-otter.json
         └── stackwright-foreman-otter.json
-        
+
         # Use with Code Puppy:
         # The otter configs are auto-loaded
 

--- a/examples/stackwright-docs/stackwright.yml
+++ b/examples/stackwright-docs/stackwright.yml
@@ -5,22 +5,23 @@ meta:
 appBar:
   titleText: "Stackwright"
   backgroundColor: "primary"
-  textColor: "text"
-  colorModeToggle: false
+  textColor: "#1A1A2E"   # Dark navy for readability on yellow
+  colorModeToggle: true
+  logo:
+    type: image
+    src: ./stackwright-logo.png
+    height: 40
+    width: 40
 
 navigation:
   - label: "🦦 Home"
     href: "/"
   - label: "🚀 Getting Started"
     href: "/getting-started"
-  - label: "📦 Content Types"
-    href: "/content-types"
   - label: "⌨️ CLI"
     href: "/cli"
   - label: "🤖 Otter Raft"
     href: "/otter-raft"
-  - label: "🧪 Showcase"
-    href: "/showcase"
 
 # Search configuration (Cmd+K to open)
 search:
@@ -36,6 +37,8 @@ sidebar:
       href: "/getting-started"
     - label: "📦 Content Types"
       href: "/content-types"
+    - label: "🧪 Showcase"
+      href: "/showcase"
     - label: "🏗️ Architecture"
       href: "/architecture"
     - label: "⌨️ CLI Reference"
@@ -46,8 +49,7 @@ sidebar:
       href: "/pro"
     - label: "🙏 Acknowledgements"
       href: "/acknowledgements"
-    - label: "🧪 Showcase"
-      href: "/showcase"
+
   collapsed: false
   width: 260
   mobileBreakpoint: 768
@@ -59,25 +61,25 @@ footer:
   links:
     - label: "GitHub"
       href: "https://github.com/Per-Aspera-LLC/stackwright"
-    - label: "Example App"
-      href: "https://github.com/Per-Aspera-LLC/stackwright/tree/main/examples/hellostackwrightnext"
+    - label: "Source for this Site"
+      href: "https://github.com/Per-Aspera-LLC/stackwright/tree/main/examples/stackwright-docs"
 
 customTheme:
   id: "stackwright-docs"
   name: "Stackwright Docs"
-  description: "Dark-mode-first documentation theme with warm amber accents and monospace headings"
+  description: "Dark-mode-first documentation theme with golden yellow accents and monospace headings"
   colors:
-    primary: "#E67E22"
+    primary: "#FCC03E"   # Safety Yellow
     secondary: "#4FC3F7"
-    accent: "#D4AF37"
+    accent: "#F59E0B"   # Amber - slightly darker accent
     background: "#0B1F3A"
     surface: "#1A2C46"
     text: "#FFFFFF"
     textSecondary: "#B0BEC5"
   darkColors:
-    primary: "#D35400"
+    primary: "#D97706"   # Amber 600 - darker for dark mode
     secondary: "#0288D1"
-    accent: "#B8860B"
+    accent: "#F59E0B"   # Amber 500
     background: "#FDFDFD"
     surface: "#F5F5F5"
     text: "#1A1A2E"

--- a/packages/types/src/types/media.ts
+++ b/packages/types/src/types/media.ts
@@ -21,10 +21,24 @@ export const iconContentSchema = mediaBaseSchema.extend({
   color: z.string().optional(),
 });
 
-export const imageContentSchema = mediaBaseSchema.extend({
-  type: z.literal('image'),
-  aspect_ratio: z.number().optional(),
-});
+export const imageContentSchema = mediaBaseSchema
+  .extend({
+    type: z.literal('image'),
+    aspect_ratio: z.number().optional(),
+  })
+  .refine(
+    (data) => {
+      // Valid if: both dimensions provided, OR aspect_ratio provided
+      const hasBothDimensions = data.height !== undefined && data.width !== undefined;
+      const hasAspectRatio = data.aspect_ratio !== undefined;
+      return hasBothDimensions || hasAspectRatio;
+    },
+    {
+      message:
+        "Image must have either both 'height' and 'width', or provide 'aspect_ratio' for responsive fill mode.",
+      path: [],
+    }
+  );
 
 export const videoContentSchema = mediaBaseSchema.extend({
   type: z.literal('video'),


### PR DESCRIPTION
## Summary

Adds Zod schema validation for image dimensions to prevent runtime 500 errors.

### Changes

- **packages/types**: Add .refine() validation for image dimensions
- **examples/stackwright-docs**: 
  - Update theme colors to safety yellow (#FCC03E)
  - Fix hero images with explicit width
  - Fix video path with ./ prefix
  - Enable light/dark mode toggle

### Breaking Change

Images must now have either:
- Both `height` AND `width`, OR
- `height` AND `aspect_ratio` (fill mode)

This catches invalid YAML at build time rather than causing 500 errors at runtime.

### Testing

- [x] Build passes
- [x] Prebuild processes video correctly
- [x] Schema validation catches partial dimensions

Closes #XXX