### PR TITLE
fix(deploy): enable static export for R2 bucket hosting

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -117,20 +117,9 @@ jobs:
         run: |
           rclone sync \
             --fast-list \
-            --exclude ".next/BUILD_ID" \
-            --exclude ".next/cache/**" \
             --exclude "node_modules/**" \
             --progress \
-            examples/stackwright-docs/.next/ \
-            "R2:${{ steps.bucket.outputs.bucket }}/"
-
-      - name: Sync public assets to R2
-        run: |
-          rclone copy \
-            --fast-list \
-            --exclude "node_modules/**" \
-            --progress \
-            examples/stackwright-docs/public/ \
+            examples/stackwright-docs/out/ \
             "R2:${{ steps.bucket.outputs.bucket }}/"
 
       - name: Deployment summary

--- a/examples/stackwright-docs/next.config.js
+++ b/examples/stackwright-docs/next.config.js
@@ -7,4 +7,10 @@ module.exports = createStackwrightNextConfig({
         "@stackwright/themes",
         "@stackwright/types",
     ],
+    // Enable static export for R2/CDN hosting
+    output: 'export',
+    // Images must be unoptimized for static export
+    images: {
+        unoptimized: true,
+    },
 });


### PR DESCRIPTION
## Context
This PR enables static export for the docs site to work with R2/CF CDN hosting.

## Changes
- next.config.js: Added output export and images unoptimized
- deploy-docs.yml: Updated to sync from out directory instead of .next

## Why
Static export is required for R2 bucket hosting since it does not support Next.js server-side rendering. Without these changes, the docs returned 404 errors when served from Cloudflare CDN.

## Testing
Verify the build completes with pnpm build and the out directory contains static HTML files.