### PR TITLE
fix(deploy): add trailing slash support for R2 static hosting

### DIFF
--- a/examples/stackwright-docs/next.config.js
+++ b/examples/stackwright-docs/next.config.js
@@ -13,4 +13,6 @@ module.exports = createStackwrightNextConfig({
     images: {
         unoptimized: true,
     },
+    // Add trailing slash so URLs work without requiring explicit trailing slashes on R2/CDN hosting
+    trailingSlash: true,
 });


### PR DESCRIPTION
This PR adds `trailingSlash: true` to the Next.js config so URLs work without requiring explicit trailing slashes on R2/CDN hosting.

When deploying to R2 or other CDN providers with static export, URLs often need trailing slashes to resolve correctly. This change ensures that Next.js generates and handles URLs consistently for static hosting environments.