### PR TITLE
fix(cli): remove duplicate preInstall hook call from processTemplate

### DIFF
--- a/.changeset/fix-preinstall-double-run.md
+++ b/.changeset/fix-preinstall-double-run.md
@@ -1,0 +1,18 @@
+---
+"@stackwright/cli": patch
+---
+
+fix(cli): remove duplicate preInstall hook call from processTemplate
+
+`processTemplate()` was calling `runScaffoldHooks('preInstall', ...)` internally,
+then `scaffold.ts` called it again after `processTemplate` returned — running every
+preInstall handler twice. Worse, the second call passed the original empty `{}` object
+(not the built package.json), so hooks registered via `scaffold.ts` could never affect
+the written file.
+
+Fix: lifecycle orchestration now lives entirely in `scaffold.ts`. `buildPackageJson` is
+exported so `scaffold.ts` can build the default package.json before running preInstall
+hooks, then passes the already-hooks-modified object into `processTemplate` for writing.
+`processTemplate` no longer calls hooks.
+
+Fixes #351.

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import chalk from 'chalk';
 import { promptThemeSelection } from '../utils/theme-selector';
-import { processTemplate } from '../utils/template-processor';
+import { processTemplate, buildPackageJson } from '../utils/template-processor';
 import { outputResult, outputError, getErrorCode, formatError } from '../utils/json-output';
 import { runScaffoldHooks } from '@stackwright/scaffold-core';
 
@@ -91,6 +91,8 @@ export async function scaffold(targetDir: string, opts: ScaffoldOptions): Promis
   const packageJson: Record<string, any> = {};
   const codePuppyConfig: Record<string, any> = {};
 
+  const dependencyMode = determineDependencyMode(targetDir, opts);
+
   // Run preScaffold hooks
   await runScaffoldHooks('preScaffold', {
     targetDir,
@@ -99,7 +101,24 @@ export async function scaffold(targetDir: string, opts: ScaffoldOptions): Promis
     themeId: theme!,
     packageJson,
     codePuppyConfig,
-    dependencyMode: determineDependencyMode(targetDir, opts),
+    dependencyMode,
+  });
+
+  // Build default packageJson if preScaffold hooks didn't populate it
+  if (Object.keys(packageJson).length === 0) {
+    Object.assign(packageJson, buildPackageJson(name!, dependencyMode === 'workspace'));
+  }
+
+  // Run preInstall hooks (after files created, before any install)
+  // This is the primary hook for adding Pro dependencies
+  await runScaffoldHooks('preInstall', {
+    targetDir,
+    projectName: name!,
+    siteTitle: title!,
+    themeId: theme!,
+    packageJson,
+    codePuppyConfig,
+    dependencyMode,
   });
 
   const pages = await processTemplate({
@@ -113,20 +132,6 @@ export async function scaffold(targetDir: string, opts: ScaffoldOptions): Promis
     pages: opts.pages,
     packageJson,
     codePuppyConfig,
-  });
-
-  const dependencyMode = determineDependencyMode(targetDir, opts);
-
-  // Run preInstall hooks (after files created, before any install)
-  // This is the primary hook for adding Pro dependencies
-  await runScaffoldHooks('preInstall', {
-    targetDir,
-    projectName: name!,
-    siteTitle: title!,
-    themeId: theme!,
-    packageJson,
-    codePuppyConfig,
-    dependencyMode,
   });
 
   // If install is requested, run postInstall hooks

--- a/packages/cli/src/utils/template-processor.ts
+++ b/packages/cli/src/utils/template-processor.ts
@@ -12,7 +12,6 @@ import {
   getGenericPageHints,
 } from './scaffold-hints';
 import { fetchTemplate } from './template-fetcher';
-import { runScaffoldHooks } from '@stackwright/scaffold-core';
 
 /**
  * Walk up from the given directory looking for a pnpm-workspace.yaml.
@@ -166,17 +165,6 @@ export async function processTemplate(config: TemplateConfig): Promise<string[]>
     codePuppyConfig = {};
   }
 
-  // Run preInstall hooks - hooks can modify packageJson
-  await runScaffoldHooks('preInstall', {
-    targetDir,
-    projectName,
-    siteTitle,
-    themeId,
-    packageJson,
-    codePuppyConfig,
-    dependencyMode: useWorkspaceDeps ? 'workspace' : 'standalone',
-  });
-
   // Write package.json with all hook modifications
   const packageJsonPath = path.join(targetDir, 'package.json');
   await fs.ensureDir(path.dirname(packageJsonPath));
@@ -232,7 +220,7 @@ async function collectFiles(dir: string, base: string = ''): Promise<string[]> {
 // Non-schema builders (npm/TypeScript config — not Stackwright grammar)
 // ---------------------------------------------------------------------------
 
-function buildPackageJson(projectName: string, useWorkspaceDeps: boolean = false): object {
+export function buildPackageJson(projectName: string, useWorkspaceDeps: boolean = false): object {
   const VERSIONS = {
     tailwindcss: '^4.1.11',
     // Stackwright packages — pinned to current stable for reproducibility

--- a/packages/cli/test/commands/scaffold.test.ts
+++ b/packages/cli/test/commands/scaffold.test.ts
@@ -252,3 +252,60 @@ describe('scaffold — result shape', () => {
     expect(commands.some((c) => c.includes('pnpm dev'))).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hook lifecycle — regression tests for issue #351
+// ---------------------------------------------------------------------------
+
+describe('scaffold — preInstall hook lifecycle (issue #351)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(async () => {
+    fs.removeSync(tmpDir);
+    // Reset hook registry so registered hooks don't bleed across tests
+    const { resetForTesting } = await import('@stackwright/scaffold-core');
+    resetForTesting();
+  });
+
+  it('preInstall hook runs exactly once', async () => {
+    const { registerScaffoldHook } = await import('@stackwright/scaffold-core');
+    const spy = vi.fn();
+    registerScaffoldHook({
+      type: 'preInstall',
+      name: 'test-spy-hook',
+      handler: async () => {
+        spy();
+      },
+    });
+
+    const targetDir = path.join(tmpDir, 'hook-once');
+    await scaffold(targetDir, baseOpts({ name: 'hook-once' }));
+
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it('preInstall hook modifications appear in the written package.json', async () => {
+    const { registerScaffoldHook } = await import('@stackwright/scaffold-core');
+    registerScaffoldHook({
+      type: 'preInstall',
+      name: 'test-dep-hook',
+      handler: async (ctx) => {
+        ctx.packageJson.dependencies = {
+          ...((ctx.packageJson.dependencies as Record<string, string>) ?? {}),
+          '@test-pro/widget': '^1.2.3',
+        };
+      },
+    });
+
+    const targetDir = path.join(tmpDir, 'hook-writes');
+    await scaffold(targetDir, baseOpts({ name: 'hook-writes' }));
+
+    const pkg = readJson(path.join(targetDir, 'package.json'));
+    const deps = pkg.dependencies as Record<string, string>;
+    expect(deps['@test-pro/widget']).toBe('^1.2.3');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #351.

`processTemplate()` was calling `runScaffoldHooks('preInstall', ...)` internally, then `scaffold.ts` called it again after `processTemplate` returned — running every `preInstall` handler twice. Worse, the second call passed the original empty `{}` object (before `buildPackageJson` had run), so hooks registered via `scaffold.ts` could never affect the written `package.json`.

## Root Cause

`processTemplate` reassigned its local `packageJson` variable (`packageJson = buildPackageJson(...)`), severing the reference held by `scaffold.ts`. The caller was left with the original empty `{}`, making its `preInstall` call a no-op against the written file.

## Fix

Lifecycle orchestration now lives entirely in `scaffold.ts`:

1. `buildPackageJson` is exported from `template-processor.ts`
2. `scaffold.ts` builds the default `packageJson` (if `preScaffold` hooks didn't populate it) before `preInstall` fires
3. `preInstall` hooks run **before** `processTemplate` is called, on the fully-built object
4. `processTemplate` writes the already-hooks-modified `packageJson` without calling hooks itself
5. `determineDependencyMode` deduplicated to a single call

## Testing

Added two regression tests to `scaffold.test.ts`:
- `preInstall` hook runs exactly once
- `preInstall` hook modifications appear in the written `package.json`

All 176 existing tests continue to pass.

## Files Changed

- `packages/cli/src/utils/template-processor.ts` — removed hook call, exported `buildPackageJson`
- `packages/cli/src/commands/scaffold.ts` — hoisted dependency mode, builds `packageJson` before hooks, moved `preInstall` call before `processTemplate`
- `packages/cli/test/commands/scaffold.test.ts` — regression tests for hook lifecycle
- `.changeset/fix-preinstall-double-run.md` — patch changeset for `@stackwright/cli`