### PR TITLE
fix(cli): --install flag now runs pnpm install before postInstall hooks

### DIFF
--- a/.changeset/fix-352-install-flag-actually-installs.md
+++ b/.changeset/fix-352-install-flag-actually-installs.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/cli": patch
+---
+
+fix(cli): --install flag now runs pnpm install before postInstall hooks

--- a/packages/cli/src/commands/scaffold.ts
+++ b/packages/cli/src/commands/scaffold.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import { Command } from 'commander';
 import { input } from '@inquirer/prompts';
 import path from 'path';
@@ -134,8 +135,9 @@ export async function scaffold(targetDir: string, opts: ScaffoldOptions): Promis
     codePuppyConfig,
   });
 
-  // If install is requested, run postInstall hooks
+  // If install is requested, run pnpm install then postInstall hooks
   if (opts.install) {
+    execSync('pnpm install', { cwd: targetDir, stdio: 'inherit' });
     await runScaffoldHooks('postInstall', {
       targetDir,
       projectName: name!,
@@ -167,7 +169,7 @@ export async function scaffold(targetDir: string, opts: ScaffoldOptions): Promis
     pagesDir: path.join(targetDir, 'pages'),
     nextSteps: [
       { command: `cd ${targetDir}`, description: 'Enter the project directory' },
-      { command: 'pnpm install', description: 'Install dependencies' },
+      ...(opts.install ? [] : [{ command: 'pnpm install', description: 'Install dependencies' }]),
       { command: 'pnpm dev', description: 'Start the development server' },
     ],
   };


### PR DESCRIPTION
Fixes #352

## Problem
`scaffold()` checked `if (opts.install)` to run `postInstall` hooks but never actually executed `pnpm install`. This meant:
- `postInstall` hooks fired against a missing `node_modules`
- Pro packages that verify installation in `postInstall` could never do meaningful work
- The `--install` flag name was misleading — it implied packages would be installed

## Fix
- Added `execSync('pnpm install', { cwd: targetDir, stdio: 'inherit' })` before `postInstall` hooks run
- Made the `nextSteps` output conditional — if `--install` was passed, the `pnpm install` step is omitted from the printed next-steps since it already ran

## Testing
Manual: scaffold a new project with `--install` and verify `node_modules` is populated before postInstall hooks run.