### PR TITLE
feat(types,build-scripts): pro plugin content schema extension + YAML mapping-key normalization

### DIFF
--- a/.changeset/add-plugin-content-schema-extension.md
+++ b/.changeset/add-plugin-content-schema-extension.md
@@ -1,0 +1,7 @@
+---
+"@stackwright/types": minor
+---
+
+Add `contentItemSchemas` and `knownContentTypeKeys` to `PrebuildPlugin` interface.
+Add `buildExtendedPageContentSchema()` function for merging OSS and plugin content schemas.
+Add `ValidatePageContentOptions` to `validatePageContent()` for plugin-aware validation.

--- a/.changeset/add-pro-content-normalization.md
+++ b/.changeset/add-pro-content-normalization.md
@@ -1,0 +1,6 @@
+---
+"@stackwright/build-scripts": minor
+---
+
+Add content format normalization (mapping-key YAML format → type-field format) to prebuild pipeline.
+Plugin `contentItemSchemas` and `knownContentTypeKeys` are now applied during page validation.

--- a/.changeset/feat-188-page-add-content-flag.md
+++ b/.changeset/feat-188-page-add-content-flag.md
@@ -1,0 +1,7 @@
+---
+"@stackwright/cli": patch
+---
+
+feat(cli): add --content flag to `page add` for inline YAML (#188)
+
+Agents can now create a page with full content in a single command instead of a two-step add + write sequence. Content is validated before writing; invalid YAML is rejected with field-level errors.

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -29,6 +29,7 @@ import {
   collectionConfigSchema,
   VIDEO_EXTENSIONS as VIDEO_EXTENSIONS_ARRAY,
   resolveEnvVarsDeep,
+  buildExtendedPageContentSchema,
 } from '@stackwright/types';
 import type {
   CollectionConfig,
@@ -881,6 +882,79 @@ function injectCollectionEntries(
   return result;
 }
 
+// ---------------------------------------------------------------------------
+// Content format normalization
+//
+// Pro content items may be authored in YAML mapping-key-as-type format:
+//   - page_header:
+//       title: "Hello"
+//
+// This normalizes them to the OSS type-field format:
+//   - type: page_header
+//     title: "Hello"
+// ---------------------------------------------------------------------------
+
+function normalizeNestedContent(obj: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...obj };
+  if (Array.isArray(obj.content_items)) {
+    result.content_items = (obj.content_items as unknown[]).map(normalizeContentItem);
+  }
+  if (Array.isArray(obj.tabs)) {
+    result.tabs = (obj.tabs as unknown[]).map(normalizeContentItem);
+  }
+  if (Array.isArray(obj.columns)) {
+    result.columns = (obj.columns as Record<string, unknown>[]).map((col) => ({
+      ...col,
+      ...(Array.isArray(col.content_items)
+        ? { content_items: (col.content_items as unknown[]).map(normalizeContentItem) }
+        : {}),
+    }));
+  }
+  return result;
+}
+
+function normalizeContentItem(item: unknown): unknown {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return item;
+  const obj = item as Record<string, unknown>;
+
+  // Already in OSS format (has 'type' string field) — just recurse into nested items
+  if (typeof obj.type === 'string') {
+    return normalizeNestedContent(obj);
+  }
+
+  // Check for mapping-key format: exactly one key whose value is a plain object
+  const keys = Object.keys(obj);
+  if (keys.length === 1) {
+    const [typeKey] = keys;
+    const value = obj[typeKey];
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const normalized: Record<string, unknown> = {
+        type: typeKey,
+        ...(value as Record<string, unknown>),
+      };
+      return normalizeNestedContent(normalized);
+    }
+  }
+
+  return obj;
+}
+
+function normalizePageContent(rawContent: unknown): unknown {
+  if (!rawContent || typeof rawContent !== 'object') return rawContent;
+  const page = rawContent as Record<string, unknown>;
+  const content = page.content as Record<string, unknown> | undefined;
+  if (!content) return rawContent;
+  const items = content.content_items;
+  if (!Array.isArray(items)) return rawContent;
+  return {
+    ...page,
+    content: {
+      ...content,
+      content_items: items.map(normalizeContentItem),
+    },
+  };
+}
+
 // -- Plugin Execution -------------------------------------------------------
 
 /**
@@ -923,6 +997,10 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
   const projectRoot =
     typeof options === 'string' ? options : (options?.projectRoot ?? process.cwd());
   const plugins = typeof options === 'object' && options !== null ? (options.plugins ?? []) : [];
+
+  // Collect extra content schemas and known type keys from all plugins
+  const extraContentSchemas = plugins.flatMap((p) => p.contentItemSchemas ?? []);
+  const pluginKnownTypes = plugins.flatMap((p) => p.knownContentTypeKeys ?? []);
 
   const pagesDir = path.join(projectRoot, 'pages');
   const publicDir = path.join(projectRoot, 'public');
@@ -1026,8 +1104,14 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
     const label = slug ?? '(root)';
     const rawContent = yaml.load(fs.readFileSync(filePath, 'utf8'));
 
-    // Validate using shared validator (includes unknown content type checking)
-    const pageValidation = validatePageContent(rawContent);
+    // Normalize mapping-key format to type-field format (backward compat for pro content)
+    const normalizedContent = normalizePageContent(rawContent);
+
+    // Validate using shared validator — extended with plugin schemas if provided
+    const pageValidation = validatePageContent(normalizedContent, {
+      extraContentItemSchemas: extraContentSchemas,
+      allowedExtraTypes: pluginKnownTypes,
+    });
     if (!pageValidation.valid) {
       const output = [
         `Invalid content: ${filePath}`,
@@ -1044,7 +1128,7 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
     const publicPrefix = `/images/${slugDir}`;
 
     const processedContent = processPageContent(
-      rawContent,
+      normalizedContent,
       contentDir,
       imageDestDir,
       publicPrefix,

--- a/packages/cli/src/commands/page.ts
+++ b/packages/cli/src/commands/page.ts
@@ -230,17 +230,39 @@ export function registerPage(program: Command): void {
     .command('add <slug>')
     .description('Create a new page with boilerplate content')
     .option('--heading <heading>', 'Page heading text')
+    .option(
+      '--content <yaml>',
+      'YAML content for the page (skips boilerplate, validates before writing)'
+    )
     .option('--json', 'Output machine-readable JSON')
-    .action(async (slug: string, opts: { heading?: string; json?: boolean }) => {
+    .action(async (slug: string, opts: { heading?: string; content?: string; json?: boolean }) => {
       const json = Boolean(opts.json);
       try {
         const { pagesDir } = detectProject();
-        const heading =
-          opts.heading ?? (!json ? await input({ message: 'Page heading:', default: slug }) : slug);
-        const result = await addPage(pagesDir, slug, { heading });
-        outputResult(result, { json }, () => {
-          console.log(chalk.green(`Created ${result.path}`));
-        });
+        if (opts.content !== undefined) {
+          // --content path: validate and write directly, skip heading prompt entirely
+          const result = writePage(pagesDir, slug, opts.content);
+          if (!result.created) {
+            outputError(
+              `Page already exists: ${result.path}\n  Hint: Use "stackwright page write <slug>" to update an existing page.`,
+              'PAGE_EXISTS',
+              { json }
+            );
+            return;
+          }
+          outputResult(result, { json }, () => {
+            console.log(chalk.green(`Created ${result.path}`));
+          });
+        } else {
+          // Existing boilerplate path: completely unchanged
+          const heading =
+            opts.heading ??
+            (!json ? await input({ message: 'Page heading:', default: slug }) : slug);
+          const result = await addPage(pagesDir, slug, { heading });
+          outputResult(result, { json }, () => {
+            console.log(chalk.green(`Created ${result.path}`));
+          });
+        }
       } catch (err: unknown) {
         const code = getErrorCode(err);
         if (code === 'NOT_A_PROJECT') {
@@ -255,6 +277,8 @@ export function registerPage(program: Command): void {
               ? '\n  Hint: Use "stackwright page write <slug>" to update an existing page.'
               : '';
           outputError(formatError(err) + hint, code, { json });
+        } else if (code === 'VALIDATION_FAILED' || code === 'YAML_PARSE_ERROR') {
+          outputError(formatError(err), code, { json });
         } else {
           outputError(formatError(err), 'ADD_PAGE_FAILED', { json }, 2);
         }

--- a/packages/cli/test/commands/page.test.ts
+++ b/packages/cli/test/commands/page.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { addPage, listPages, validatePages } from '../../src/commands/page';
+import { addPage, listPages, validatePages, writePage } from '../../src/commands/page';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -127,6 +127,65 @@ describe('listPages', () => {
     const result = listPages(pagesDir);
     const page = result.pages.find((p) => p.slug === '/empty-page');
     expect(page?.heading).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writePage (via addPage --content path)
+// ---------------------------------------------------------------------------
+
+const VALID_PAGE_YAML = `content:
+  content_items:
+    - type: main
+      label: "test-hero"
+      heading:
+        text: "Test Page"
+        textSize: "h1"
+      textBlocks:
+        - text: "Hello world"
+          textSize: "body1"
+`;
+
+describe('writePage (via addPage --content path)', () => {
+  let pagesDir: string;
+
+  beforeEach(() => {
+    pagesDir = path.join(makeTmpDir(), 'pages');
+    fs.ensureDirSync(pagesDir);
+  });
+
+  it('creates the file and returns created: true for a new page', () => {
+    const result = writePage(pagesDir, 'new-page', VALID_PAGE_YAML);
+    expect(result.created).toBe(true);
+    expect(fs.existsSync(result.path)).toBe(true);
+    expect(result.slug).toBe('/new-page');
+  });
+
+  it('throws VALIDATION_FAILED for structurally invalid YAML', () => {
+    const badStructure =
+      'content:\n  content_items:\n    - type: totally_fake_type\n      label: "oops"\n';
+    expect(() => writePage(pagesDir, 'bad-page', badStructure)).toThrow();
+    try {
+      writePage(pagesDir, 'bad-page-2', badStructure);
+    } catch (err: unknown) {
+      expect((err as NodeJS.ErrnoException).code).toBe('VALIDATION_FAILED');
+    }
+  });
+
+  it('returns created: false when writing to an already-existing page', () => {
+    writePage(pagesDir, 'existing-page', VALID_PAGE_YAML);
+    const result = writePage(pagesDir, 'existing-page', VALID_PAGE_YAML);
+    expect(result.created).toBe(false);
+  });
+
+  it('throws YAML_PARSE_ERROR for unparseable YAML syntax', () => {
+    const unparseable = '{ bad yaml: : :';
+    expect(() => writePage(pagesDir, 'syntax-error-page', unparseable)).toThrow();
+    try {
+      writePage(pagesDir, 'syntax-error-page-2', unparseable);
+    } catch (err: unknown) {
+      expect((err as NodeJS.ErrnoException).code).toBe('YAML_PARSE_ERROR');
+    }
   });
 });
 

--- a/packages/types/src/types/layout.ts
+++ b/packages/types/src/types/layout.ts
@@ -78,6 +78,36 @@ export const pageContentSchema = z.object({
   }),
 });
 
+/**
+ * Build an extended page content schema that includes additional content item schemas.
+ *
+ * Used by the prebuild pipeline to support pro/plugin content types alongside
+ * the built-in OSS content types.
+ *
+ * @param extraSchemas - Additional Zod schemas to include in the content item union
+ * @returns Extended page content schema
+ */
+export function buildExtendedPageContentSchema(extraSchemas: z.ZodTypeAny[]): z.ZodTypeAny {
+  if (extraSchemas.length === 0) return pageContentSchema;
+
+  const extendedContentItem = z.union([contentItemSchema, ...extraSchemas] as [
+    z.ZodTypeAny,
+    z.ZodTypeAny,
+    ...z.ZodTypeAny[],
+  ]);
+
+  return z.object({
+    content: z.object({
+      meta: pageMetaSchema.optional(),
+      app_bar: appBarContentSchema.optional(),
+      footer: footerContentSchema.optional(),
+      content_items: z.array(extendedContentItem),
+      list_icon: z.string().optional(),
+      navSidebar: pageSidebarSchema,
+    }),
+  });
+}
+
 export type PageMeta = z.infer<typeof pageMetaSchema>;
 export type FooterContent = z.infer<typeof footerContentSchema>;
 export type PageContent = z.infer<typeof pageContentSchema>;

--- a/packages/types/src/types/plugin.ts
+++ b/packages/types/src/types/plugin.ts
@@ -62,6 +62,41 @@ export interface PrebuildPlugin {
   configSchema?: z.ZodSchema;
 
   /**
+   * Additional Zod schemas for content items provided by this plugin.
+   *
+   * When registered, the prebuild will include these schemas in the content
+   * item union validator, allowing pro content types to pass validation.
+   * Each schema should match objects with a `type` field set to the plugin's
+   * content type name(s).
+   *
+   * @example
+   * ```typescript
+   * const myPlugin: PrebuildPlugin = {
+   *   name: 'pro-content',
+   *   contentItemSchemas: [
+   *     z.object({ type: z.literal('page_header') }).passthrough(),
+   *     z.object({ type: z.literal('stats_grid') }).passthrough(),
+   *   ],
+   * };
+   * ```
+   */
+  contentItemSchemas?: z.ZodTypeAny[];
+
+  /**
+   * Additional content type key strings recognized by this plugin.
+   *
+   * Type strings listed here will NOT generate "unknown content type" errors
+   * during prebuild validation. Should match the `type` values used in the
+   * plugin's content item schemas.
+   *
+   * @example
+   * ```typescript
+   * knownContentTypeKeys: ['page_header', 'stats_grid', 'two_column_layout'],
+   * ```
+   */
+  knownContentTypeKeys?: readonly string[];
+
+  /**
    * Called after site config is loaded but before page/collection processing
    *
    * Use this hook to:

--- a/packages/types/src/types/validation.ts
+++ b/packages/types/src/types/validation.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import { contentItemSchema, KNOWN_CONTENT_TYPE_KEYS, type GridColumn } from './content';
-import { pageContentSchema } from './layout';
+import { pageContentSchema, buildExtendedPageContentSchema } from './layout';
 import { CONTENT_TYPE_HINTS, getContentTypeHints, suggestContentType } from './validation-hints';
 
 // ============================================================================
@@ -259,7 +259,10 @@ function createHint(issue: z.ZodIssue, root: Record<string, unknown>): Validatio
 /**
  * Check for unknown content type keys in content items.
  */
-function checkUnknownContentTypes(root: Record<string, unknown>): ValidationError[] {
+function checkUnknownContentTypes(
+  root: Record<string, unknown>,
+  allowedExtraTypes: readonly string[] = []
+): ValidationError[] {
   const errors: ValidationError[] = [];
 
   walkContentItems(root, (item, path) => {
@@ -286,7 +289,7 @@ function checkUnknownContentTypes(root: Record<string, unknown>): ValidationErro
       return;
     }
 
-    if (!KNOWN_CONTENT_TYPE_KEYS.includes(type as any)) {
+    if (!KNOWN_CONTENT_TYPE_KEYS.includes(type as any) && !allowedExtraTypes.includes(type)) {
       const suggested = suggestContentType(type);
       errors.push({
         path,
@@ -310,12 +313,39 @@ function checkUnknownContentTypes(root: Record<string, unknown>): ValidationErro
 // ============================================================================
 
 /**
+ * Options for validatePageContent.
+ */
+export interface ValidatePageContentOptions {
+  /**
+   * Additional Zod schemas for pro/plugin content item types.
+   * These are merged into the content item union during validation.
+   */
+  extraContentItemSchemas?: z.ZodTypeAny[];
+
+  /**
+   * Additional content type key strings to treat as valid.
+   * Type strings listed here will NOT generate "unknown content type" errors.
+   */
+  allowedExtraTypes?: readonly string[];
+}
+
+/**
  * Validate page content YAML against the schema.
  * Returns structured validation result with AI-friendly errors.
  */
-export function validatePageContent(yamlContent: unknown): ValidationResult {
+export function validatePageContent(
+  yamlContent: unknown,
+  options?: ValidatePageContentOptions
+): ValidationResult {
+  const extraSchemas = options?.extraContentItemSchemas ?? [];
+  const allowedExtraTypes = options?.allowedExtraTypes ?? [];
+
+  // Choose schema: extended (with pro types) or standard
+  const effectiveSchema =
+    extraSchemas.length > 0 ? buildExtendedPageContentSchema(extraSchemas) : pageContentSchema;
+
   // First pass: Zod schema validation
-  const result = pageContentSchema.safeParse(yamlContent);
+  const result = effectiveSchema.safeParse(yamlContent);
 
   const errors: ValidationError[] = [];
 
@@ -331,7 +361,10 @@ export function validatePageContent(yamlContent: unknown): ValidationResult {
 
   // Second pass: check for unknown content types (catches typos before Zod strips them)
   if (typeof yamlContent === 'object' && yamlContent !== null) {
-    const unknownTypeErrors = checkUnknownContentTypes(yamlContent as Record<string, unknown>);
+    const unknownTypeErrors = checkUnknownContentTypes(
+      yamlContent as Record<string, unknown>,
+      allowedExtraTypes
+    );
     errors.push(...unknownTypeErrors);
   }
 


### PR DESCRIPTION
## Summary

Enables pro packages to extend the Stackwright prebuild content schema with their own content item types, and adds backward-compatible normalization for YAML mapping-key-as-type format.

## Changes

### `@stackwright/types` (minor)

**`PrebuildPlugin` interface** — two new optional fields:
- `contentItemSchemas?: z.ZodTypeAny[]` — Zod schemas for pro content item types. The prebuild merges these with the built-in OSS union during validation, so pro content types pass without errors.
- `knownContentTypeKeys?: readonly string[]` — Type strings that suppress 'unknown content type' validation errors. Should match the types in `contentItemSchemas`.

**`buildExtendedPageContentSchema(extraSchemas)`** — new export in `layout.ts`. Builds a page content schema that accepts both OSS and plugin content types. Zero-cost (returns `pageContentSchema` unchanged) when no extras are provided.

**`validatePageContent(content, options?)`** — updated signature accepts `ValidatePageContentOptions`:
- `extraContentItemSchemas` — merged into the content item union
- `allowedExtraTypes` — type strings excluded from 'unknown type' errors

### `@stackwright/build-scripts` (minor)

**Content format normalization** — `runPrebuild` now normalizes YAML mapping-key-as-type format before validation:
```yaml
# Before (pro otter output — YAML key IS the type)
- page_header:
    title: "Hello"

# After normalization (OSS type-field format)
- type: page_header
  title: "Hello"
```
Normalization is recursive — handles nested `content_items`, `tabs`, and grid `columns`.

**Plugin schema collection** — `contentItemSchemas` and `knownContentTypeKeys` from all registered plugins are collected and passed to `validatePageContent()` as options.

## Motivation

Pro packages (e.g. `@stackwright-pro/display-components`) can now export a `PrebuildPlugin` that registers their content item schemas. When passed to `runPrebuild({ plugins: [proPlugin] })`, pro content types (`page_header`, `stats_grid`, etc.) validate cleanly alongside OSS types.

## Breaking Changes

None. All additions are optional/backward-compatible. `validatePageContent` and `runPrebuild` signatures are extended but not changed.

## Changesets

- `@stackwright/types`: minor
- `@stackwright/build-scripts`: minor