### PR TITLE
fix(build-scripts): preserve this binding in executePluginHook

### DIFF
--- a/.changeset/fix-plugin-this-binding.md
+++ b/.changeset/fix-plugin-this-binding.md
@@ -1,0 +1,14 @@
+---
+"@stackwright/build-scripts": patch
+---
+
+fix(executePluginHook): preserve `this` binding when calling plugin lifecycle hooks
+
+`executePluginHook` was extracting hook methods as unbound references
+(`const hookFn = plugin[hook]`) and calling them as plain functions
+(`hookFn(context)`). In strict-mode ES classes, this strips `this`,
+causing any plugin that calls a private/instance method from `beforeBuild`
+or `afterBuild` to throw `Cannot read properties of undefined`.
+
+Fix: use `hookFn.call(plugin, context)` so the plugin instance is always
+the receiver.

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -970,7 +970,7 @@ async function executePluginHook(
 
   try {
     console.log(`  Running ${plugin.name} (${hook})...`);
-    await Promise.resolve(hookFn(context));
+    await Promise.resolve(hookFn.call(plugin, context));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Plugin "${plugin.name}" failed during ${hook}: ${message}`);

--- a/packages/build-scripts/test/plugin-hooks.test.ts
+++ b/packages/build-scripts/test/plugin-hooks.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { runPrebuild } from '../src/prebuild';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a minimal but fully-valid project root with stackwright.yml.
+ * Must satisfy siteConfigSchema (title + navigation + appBar are required).
+ */
+function makeTempProject(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-plugin-test-'));
+  fs.writeFileSync(
+    path.join(dir, 'stackwright.yml'),
+    `title: Test Site\nnavigation: []\nappBar:\n  titleText: Test Site\n`
+  );
+  fs.mkdirSync(path.join(dir, 'pages'), { recursive: true });
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin hook execution — regression suite
+// ---------------------------------------------------------------------------
+
+describe('plugin hook execution', () => {
+  it('preserves this binding for class-based plugins (regression: executePluginHook this-binding)', async () => {
+    /**
+     * This is the exact scenario that was broken:
+     *
+     * executePluginHook did:
+     *   const hookFn = plugin[hook];
+     *   await Promise.resolve(hookFn(context));   // ← this === undefined in strict mode
+     *
+     * Any class-based plugin that calls a private/instance method from a
+     * lifecycle hook would throw "Cannot read properties of undefined".
+     *
+     * Fix: hookFn.call(plugin, context) preserves the plugin as receiver.
+     */
+    const projectRoot = makeTempProject();
+    const calls: string[] = [];
+
+    class TrackingPlugin {
+      name = 'test-tracking-plugin';
+
+      async beforeBuild(context: { projectRoot: string; siteConfig: Record<string, unknown> }) {
+        // This call to a private method is exactly what was broken before the fix.
+        // hookFn(context) stripped `this`, making this.recordCall undefined.
+        this.recordCall('beforeBuild', context.projectRoot);
+      }
+
+      async afterBuild(context: { projectRoot: string; siteConfig: Record<string, unknown> }) {
+        this.recordCall('afterBuild', context.projectRoot);
+      }
+
+      private recordCall(hook: string, root: string) {
+        calls.push(`${hook}:${root}`);
+      }
+    }
+
+    await runPrebuild({ projectRoot, plugins: [new TrackingPlugin()] });
+
+    expect(calls).toContain(`beforeBuild:${projectRoot}`);
+    expect(calls).toContain(`afterBuild:${projectRoot}`);
+  });
+
+  it('passes siteConfig and projectRoot in context to plugin hooks', async () => {
+    const projectRoot = makeTempProject();
+    let capturedContext: unknown = null;
+
+    const plugin = {
+      name: 'context-capture-plugin',
+      async beforeBuild(ctx: unknown) {
+        capturedContext = ctx;
+      },
+    };
+
+    await runPrebuild({ projectRoot, plugins: [plugin] });
+
+    expect(capturedContext).toMatchObject({
+      projectRoot,
+      siteConfig: expect.objectContaining({ title: 'Test Site' }),
+    });
+  });
+
+  it('wraps plugin errors with plugin name and hook in message', async () => {
+    const projectRoot = makeTempProject();
+
+    const plugin = {
+      name: 'failing-plugin',
+      async beforeBuild() {
+        throw new Error('something went wrong internally');
+      },
+    };
+
+    await expect(runPrebuild({ projectRoot, plugins: [plugin] })).rejects.toThrow(
+      'Plugin "failing-plugin" failed during beforeBuild: something went wrong internally'
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`executePluginHook` extracts plugin lifecycle hooks as unbound method references and calls them without a receiver:

```typescript
const hookFn = plugin[hook];
await Promise.resolve(hookFn(context)); // this === undefined in strict mode
```

For class-based plugins, this strips `this`. Any call to a private or instance method inside `beforeBuild`/`afterBuild` throws:
> `Cannot read properties of undefined (reading '...')`

## Reproducer

`@stackwright-pro/openapi`'s `OpenAPIPlugin.beforeBuild` calls `this.processIntegration()`, causing `pnpm build` to fail in the marine-logistics test project with exactly this error.

## Fix

Use `hookFn.call(plugin, context)` to preserve the plugin instance as the receiver — one line change.

## Tests

Added `test/plugin-hooks.test.ts` with three regression cases covering class-method `this` binding, context shape, and error wrapping. No plugin hook tests existed before this PR (bugs drive CI).

## Changeset

Patch bump for `@stackwright/build-scripts`.