### PR TITLE
fix(build-scripts): create parent dir for nested page slug output files

### DIFF
--- a/.changeset/fix-prebuild-mkdir-nested-slugs.md
+++ b/.changeset/fix-prebuild-mkdir-nested-slugs.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/build-scripts": patch
+---
+
+fix(build-scripts): create parent directory before writing nested page slug output files

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -1139,7 +1139,9 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
     const expandedContent = injectCollectionEntries(processedContent, collectionIndexes);
 
     const outFile = slug ? `${slug}.json` : '_root.json';
-    fs.writeFileSync(path.join(contentOutDir, outFile), JSON.stringify(expandedContent, null, 2));
+    const outPath = path.join(contentOutDir, outFile);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, JSON.stringify(expandedContent, null, 2));
     console.log(`  OK ${outFile}  (${label})`);
   }
 


### PR DESCRIPTION
## Problem

When a content page lives under a nested directory (e.g. `pages/missions/[id]/content.yml`), the prebuild derives a slug of `missions/[id]` and writes to `public/stackwright-content/missions/[id].json`. The parent subdirectory `missions/` was never created, causing:

```
ENOENT: no such file or directory, open .../public/stackwright-content/missions/[id].json
```

Root-level slugs (e.g. `dashboard`) were unaffected because their parent is `contentOutDir` itself, which is always created upfront.

## Fix

Added `fs.mkdirSync(path.dirname(outPath), { recursive: true })` immediately before the `writeFileSync` call in the page-writing loop of `runPrebuild`. The `recursive: true` flag makes this a no-op when the directory already exists, so root-level pages are unaffected.

## Affected packages
- `@stackwright/build-scripts` — patch