### PR TITLE
fix(ci): remove duplicate pull_request trigger from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
 
 permissions:
   contents: write
@@ -21,7 +16,7 @@ jobs:
     # Squash merges embed individual commit messages in the body, and automated
     # commits (prerelease bumps, etc.) include [skip ci] — which would incorrectly
     # suppress the release workflow if we used contains() on the full body.
-    if: "${{ !startsWith(github.event.head_commit.message, 'chore: version packages for release [skip ci]') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: version packages for release [skip ci]') }}"
     steps:
       - name: Generate PerAsperaCI token
         id: app-token
@@ -42,7 +37,6 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
-          provenance: true
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Problem

The Release workflow had a dual-trigger race condition that caused a guaranteed push rejection on every PR merge to `main`.

### Root cause

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
    types: [closed]
```

When a PR merges into `main`, GitHub fires **both** a `push` event and a `pull_request: closed` event at the same time. This spawned two concurrent Release workflow runs that both:
1. Checked out `main`
2. Versioned packages and committed locally
3. Raced to `git push origin main`

The loser (whichever runner got there second) was always rejected with:
```
! [rejected] main -> main (fetch first)
error: failed to push some refs to 'https://github.com/Per-Aspera-LLC/stackwright'
```

This was observed in run [25080842050](https://github.com/Per-Aspera-LLC/stackwright/actions/runs/25080842050/job/73485295380) triggered by PR #391. The `push` trigger alone is sufficient — merging a PR **always** creates a push event on the target branch.

## Changes

### Bug 1 (Critical): Remove the `pull_request` trigger block
The `push: branches: [main]` trigger alone covers all cases. Removed the entire `pull_request` block.

### Bug 2 (Secondary): Harden the `[skip ci]` guard  
`github.event.head_commit.message` is only populated for `push` events — it's `null` for `pull_request` events, which means the guard was silently a no-op for PR-triggered runs. Added an explicit `github.event_name == 'push'` check to make the intent clear and future-proof against any trigger re-addition.

### Bug 3 (Minor): Remove `provenance: true` from `actions/setup-node@v5`
`provenance` is an `npm publish` flag, not a valid input for `actions/setup-node`. It caused a yellow warning annotation on every run. Provenance attestation is already correctly applied via `--provenance` in the `npm publish` command later in the workflow.

## Diff

```diff
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed

-    if: "${{ !startsWith(github.event.head_commit.message, '...') }}"
+    if: "${{ github.event_name == 'push' && !startsWith(github.event.head_commit.message, '...') }}"

-          provenance: true
```