### PR TITLE
fix(changeset): correct phantom version baselines after failed npm publish

### DIFF
--- a/.changeset/fix-prebuild-mkdir-nested-slugs.md
+++ b/.changeset/fix-prebuild-mkdir-nested-slugs.md
@@ -1,5 +1,0 @@
----
-"@stackwright/build-scripts": patch
----
-
-fix(build-scripts): create parent directory before writing nested page slug output files

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -3,16 +3,16 @@
   "tag": "alpha",
   "initialVersions": {
     "stackwright-docs": "0.1.2",
-    "@stackwright/build-scripts": "0.5.0",
-    "@stackwright/cli": "0.8.0",
+    "@stackwright/build-scripts": "0.5.1",
+    "@stackwright/cli": "0.8.1",
     "@stackwright/collections": "0.1.0",
     "@stackwright/core": "0.8.0",
     "@stackwright/e2e": "0.3.0",
     "@stackwright/hooks-registry": "0.1.0",
     "@stackwright/icons": "0.5.0",
-    "launch-stackwright": "0.2.0",
+    "launch-stackwright": "0.2.1",
     "@stackwright/maplibre": "2.0.0",
-    "@stackwright/mcp": "0.4.0",
+    "@stackwright/mcp": "0.4.1",
     "@stackwright/nextjs": "0.4.0",
     "@stackwright/otters": "0.2.0",
     "@stackwright/sbom-generator": "0.2.0",
@@ -21,17 +21,5 @@
     "@stackwright/types": "1.2.0",
     "@stackwright/ui-shadcn": "0.1.1"
   },
-  "changesets": [
-    "add-plugin-content-schema-extension",
-    "add-pro-content-normalization",
-    "dependabot-batch-updates",
-    "feat-188-page-add-content-flag",
-    "feat-243-security-headers",
-    "fix-352-install-flag-actually-installs",
-    "fix-plugin-config-schema-242",
-    "fix-plugin-this-binding",
-    "fix-prebuild-mkdir-nested-slugs",
-    "fix-preinstall-double-run",
-    "grumpy-paws-create"
-  ]
+  "changesets": []
 }


### PR DESCRIPTION
## Problem

After PR #391 merged to `main`, the automated release workflow bumped `build-scripts→0.5.1`, `cli→0.8.1`, `mcp→0.4.1`, and `launch-stackwright→0.2.1` — but **all npm publishes 404'd** (packages not yet on the public registry). The back-merge of `main` into `dev` wrote those phantom stable versions into dev's `package.json` files, corrupting the prerelease state in **two distinct ways**:

### Bug 1: Stale `initialVersions` in `pre.json`

`pre.json.initialVersions` still listed the pre-bump versions (`0.5.0`, `0.8.0`, `0.4.0`, `0.2.0`). Changesets uses these as the baseline for computing next versions. With the current package.json versions higher than `initialVersions`, `changeset status` errored:
```
🦋  error Some packages have been changed but no changesets were found.
```

### Bug 2: `pre.json.changesets` listed all IDs as 'already applied'

This is the root cause. `assembleReleasePlan` in prerelease mode filters changesets via:
```js
let usedChangesetIds = new Set(preState.changesets);
return changesets.filter(changeset => !usedChangesetIds.has(changeset.id));
```
All 10 changeset IDs were in `pre.json.changesets`, so **every pending changeset was filtered out**. `getReleasePlan` returned 0 changesets and 0 releases. Combined with `getVersionableChangedPackages` detecting real changes vs `main`, the `changedPackages > 0 && changesets === 0` error condition fired.

The prerelease versions that should have been written (e.g. `build-scripts@0.6.0-alpha.0`) were overwritten by stable phantom versions during the back-merge, but Changesets didn't know this happened.

## Fix

1. **Update 4 phantom `initialVersions`** to match current `package.json` versions (`0.5.1`, `0.8.1`, `0.4.1`, `0.2.1`).
2. **Clear `pre.json.changesets` to `[]`** — all 10 pending `.md` files are now treated as unapplied. Next `changeset version` will apply them all fresh and generate correct prerelease versions.
3. **Delete the zombie `fix-prebuild-mkdir-nested-slugs` changeset** — it was already consumed (its entry exists in `build-scripts/CHANGELOG.md` under `0.5.1`). Keeping it would create a duplicate CHANGELOG entry in the next release.

## Result

```
🦋  info Packages to be bumped at patch:
🦋  - @stackwright/core, @stackwright/icons, @stackwright/maplibre,
       @stackwright/ui-shadcn, @stackwright/cli, @stackwright/mcp,
       stackwright-docs, launch-stackwright
🦋  info Packages to be bumped at minor:
🦋  - @stackwright/types, @stackwright/build-scripts, @stackwright/nextjs
🦋  info NO packages to be bumped at major
```

`pnpm changeset status` exits 0. The next `changeset version` run will produce correct `-alpha.N` prerelease versions.