### PR TITLE
feat(build-scripts): warn on plugin-declared content types + unknownContentTypes option (#399)

### DIFF
--- a/.changeset/prebuild-plugin-warnings.md
+++ b/.changeset/prebuild-plugin-warnings.md
@@ -1,0 +1,10 @@
+---
+"@stackwright/build-scripts": minor
+"@stackwright/types": minor
+---
+
+Add plugin-type warnings and `unknownContentTypes` option to prebuild
+
+**Gap 1 — plugin-declared types now emit a warning**: When a page uses a content type allowed via a plugin's `knownContentTypeKeys`, the prebuild now logs a warning reminding you to call `registerContentType()` at runtime.
+
+**Gap 2 — `unknownContentTypes` option**: `PrebuildOptions` gains `unknownContentTypes?: 'error' | 'warn' | 'ignore'` (default `'error'`). Allows demo projects or WIP builds to downgrade content validation failures from hard errors to warnings or silence.

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -448,6 +448,22 @@ function findContentFiles(dir: string, baseSlug = ''): ContentFile[] {
 // -- Content type validation ------------------------------------------------
 // NOTE: Unknown content type checking is now handled by validatePageContent()
 
+/**
+ * Recursively walk any JS value and collect all string values of fields named `type`.
+ * Used to identify which content types a page actually uses (for plugin-type warnings).
+ */
+function collectContentTypes(obj: unknown, result: Set<string> = new Set()): Set<string> {
+  if (!obj || typeof obj !== 'object') return result;
+  if (Array.isArray(obj)) {
+    for (const item of obj) collectContentTypes(item, result);
+    return result;
+  }
+  const record = obj as Record<string, unknown>;
+  if (typeof record.type === 'string') result.add(record.type);
+  for (const value of Object.values(record)) collectContentTypes(value, result);
+  return result;
+}
+
 // -- Collections ------------------------------------------------------------
 
 /** Read and validate a _collection.yaml config, or return defaults. */
@@ -997,6 +1013,10 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
   const projectRoot =
     typeof options === 'string' ? options : (options?.projectRoot ?? process.cwd());
   const plugins = typeof options === 'object' && options !== null ? (options.plugins ?? []) : [];
+  const unknownContentTypes =
+    typeof options === 'object' && options !== null
+      ? (options.unknownContentTypes ?? 'error')
+      : 'error';
 
   // Collect extra content schemas and known type keys from all plugins
   const extraContentSchemas = plugins.flatMap((p) => p.contentItemSchemas ?? []);
@@ -1120,7 +1140,27 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
             `  ${e.fieldPath}: ${e.hint}${e.suggestion ? ` (did you mean "${e.suggestion}"?)` : ''}`
         ),
       ].join('\n');
-      throw new Error(output);
+      if (unknownContentTypes === 'error') {
+        throw new Error(output);
+      } else if (unknownContentTypes === 'warn') {
+        console.warn(`  ⚠  ${output}`);
+      }
+      // 'ignore': silently continue
+    }
+
+    // Gap 1: warn when plugin-declared types are used in this page
+    if (pageValidation.valid && pluginKnownTypes.length > 0) {
+      const usedTypes = collectContentTypes(normalizedContent);
+      const pluginTypesUsed = [...usedTypes].filter((t) => pluginKnownTypes.includes(t));
+      if (pluginTypesUsed.length > 0) {
+        const declaringPlugins = plugins
+          .filter((p) => (p.knownContentTypeKeys ?? []).some((k) => pluginTypesUsed.includes(k)))
+          .map((p) => p.name);
+        console.warn(
+          `  ⚠  ${label}: uses ${pluginTypesUsed.length} plugin-declared type(s) [${declaringPlugins.join(', ')}]: ${pluginTypesUsed.join(', ')}\n` +
+            `     Ensure registerContentType() is called in your app for each of these types.`
+        );
+      }
     }
 
     const slugDir = slug ?? '_root';

--- a/packages/build-scripts/test/plugin-hooks.test.ts
+++ b/packages/build-scripts/test/plugin-hooks.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -99,5 +100,134 @@ describe('plugin hook execution', () => {
     await expect(runPrebuild({ projectRoot, plugins: [plugin] })).rejects.toThrow(
       'Plugin "failing-plugin" failed during beforeBuild: something went wrong internally'
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for content-type tests
+// ---------------------------------------------------------------------------
+
+function writePageContent(projectRoot: string, slug: string | null, yaml: string): void {
+  const dir = slug ? path.join(projectRoot, 'pages', slug) : path.join(projectRoot, 'pages');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'content.yml'), yaml);
+}
+
+// ---------------------------------------------------------------------------
+// Content type warnings and unknownContentTypes option
+// ---------------------------------------------------------------------------
+
+describe('content type warnings and unknownContentTypes option', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Gap 1: plugin-declared types trigger a warning', async () => {
+    const projectRoot = makeTempProject();
+    const plugin = {
+      name: 'pro-content',
+      knownContentTypeKeys: ['custom_widget'] as const,
+      contentItemSchemas: [z.object({ type: z.literal('custom_widget') }).passthrough()],
+    };
+    writePageContent(
+      projectRoot,
+      null,
+      `content:
+  content_items:
+    - type: custom_widget
+      label: test-widget
+`
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runPrebuild({ projectRoot, plugins: [plugin] });
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes('custom_widget'))).toBe(true);
+    expect(warnCalls.some((msg) => msg.includes('registerContentType'))).toBe(true);
+  });
+
+  it('Gap 1: core types do NOT trigger the plugin warning', async () => {
+    const projectRoot = makeTempProject();
+    const plugin = {
+      name: 'pro-content',
+      knownContentTypeKeys: ['custom_widget'] as const,
+      contentItemSchemas: [z.object({ type: z.literal('custom_widget') }).passthrough()],
+    };
+    writePageContent(
+      projectRoot,
+      null,
+      `content:
+  content_items:
+    - type: text_block
+      label: test-block
+      textBlocks: []
+`
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runPrebuild({ projectRoot, plugins: [plugin] });
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes('registerContentType'))).toBe(false);
+  });
+
+  it('Gap 2: unknownContentTypes "warn" logs but does not throw', async () => {
+    const projectRoot = makeTempProject();
+    writePageContent(
+      projectRoot,
+      null,
+      `content:
+  content_items:
+    - type: totally_unknown_xyz
+      label: bad-widget
+`
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(runPrebuild({ projectRoot, unknownContentTypes: 'warn' })).resolves.not.toThrow();
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes('totally_unknown_xyz'))).toBe(true);
+  });
+
+  it('Gap 2: unknownContentTypes "ignore" does not throw and does not warn', async () => {
+    const projectRoot = makeTempProject();
+    writePageContent(
+      projectRoot,
+      null,
+      `content:
+  content_items:
+    - type: totally_unknown_xyz
+      label: bad-widget
+`
+    );
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(
+      runPrebuild({ projectRoot, unknownContentTypes: 'ignore' })
+    ).resolves.not.toThrow();
+
+    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnCalls.some((msg) => msg.includes('totally_unknown_xyz'))).toBe(false);
+  });
+
+  it('Gap 2: default behavior ("error") still throws', async () => {
+    const projectRoot = makeTempProject();
+    writePageContent(
+      projectRoot,
+      null,
+      `content:
+  content_items:
+    - type: totally_unknown_xyz
+      label: bad-widget
+`
+    );
+
+    await expect(runPrebuild({ projectRoot })).rejects.toThrow('totally_unknown_xyz');
   });
 });

--- a/packages/types/src/types/plugin.ts
+++ b/packages/types/src/types/plugin.ts
@@ -130,4 +130,17 @@ export interface PrebuildOptions {
 
   /** Plugins to run during prebuild */
   plugins?: PrebuildPlugin[];
+
+  /**
+   * How to handle unknown or invalid content type errors during page validation.
+   *
+   * - `'error'` (default): throw and abort the build. Correct for CI/production.
+   * - `'warn'`: log a warning and continue. Useful during development or for
+   *   demo projects where content types may be ahead of their implementations.
+   * - `'ignore'`: silently skip content validation errors and continue.
+   *
+   * Note: this option does not affect site config (stackwright.yml) validation,
+   * which always fails hard on invalid config.
+   */
+  unknownContentTypes?: 'error' | 'warn' | 'ignore';
 }


### PR DESCRIPTION
Cherry-pick of 4f71be481a8c12938a7bef3d57dc133b20078fd7 from dev onto main for stable release.

## What
- Warns when plugins declare content types that Stackwright doesn't know about
- Adds `unknownContentTypes` option

## Why this PR exists
The dev→main PR showed 47 commits due to a git history divergence (phantom commits from merge-based back-merges). This targeted cherry-pick brings only the intended change to main cleanly.

## Related
- Original PR: #399
- Root cause fix: see companion PR fixing `.github/workflows/release.yml` back-merge strategy