### PR TITLE
fix(ci): use rebase instead of merge for back-merge into dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,14 +109,22 @@ jobs:
       - name: Back-merge into dev
         if: steps.check.outputs.skip != 'true'
         run: |
+          git fetch origin dev
           git checkout dev
           git pull origin dev
-          # -X theirs: main's graduated versions win over dev's stale alphas
-          git merge main -X theirs --no-edit -m "chore: back-merge main after release [skip ci]"
-          # Re-enter prerelease mode so the next dev push produces alphas
+          # Rebase dev's unique commits onto main for clean, linear history.
+          # Using rebase (instead of merge) prevents phantom commits from
+          # accumulating in dev's ancestry — which previously caused dev→main
+          # PRs to show dozens of already-released commits.
+          #
+          # -X ours: when conflicts arise (e.g. version numbers in package.json),
+          # prefer main's graduated stable versions over dev's stale alpha versions.
+          git rebase origin/main -X ours
+          # Re-enter prerelease mode so the next dev push produces alphas.
           if [ ! -f ".changeset/pre.json" ]; then
             pnpm changeset pre enter alpha
             git add .changeset/pre.json
             git commit -m "chore: re-enter prerelease mode after back-merge [skip ci]"
           fi
-          git push origin dev
+          # Force push is required after a rebase to rewrite dev's remote history.
+          git push origin dev --force-with-lease


### PR DESCRIPTION
## Problem

After each `dev→main` release, CI runs a back-merge step using `git merge main`. Because promotion PRs create new commit SHAs on main (not preserving dev's original SHAs), the merge commit embeds all old dev commits permanently as reachable ancestors of dev's HEAD.

Result: every subsequent `dev→main` PR shows all those ghost commits, even though their content already shipped.

## Fix

Switch the back-merge step from:
```bash
git merge main -X theirs --no-edit
git push origin dev
```

To:
```bash
git rebase origin/main -X ours
git push origin dev --force-with-lease
```

## Why rebase works

- Replays dev's unique commits on top of main's new tip
- No merge commit bloat in dev's ancestry
- Future `git log origin/main..origin/dev` only shows genuinely new work
- `-X ours` resolves version-number conflicts by preferring main's graduated stable versions over dev's stale alpha versions
- `--force-with-lease` is safe: this is a CI-managed branch and rebase is the intended operation

## Risk

Low. The only behavioral change is how dev's history is structured after a release. The rebase does not change any package content, versions, or changeset state — only the git DAG shape.