### PR TITLE
fix(types): export ZodLike and widen issues[].path to PropertyKey[]

### DIFF
--- a/.changeset/zodlike-export-path-fix.md
+++ b/.changeset/zodlike-export-path-fix.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/types": patch
+---
+
+Export `ZodLike` from `@stackwright/types` so plugin authors can reference it by name without index-access workarounds. Also widens `ZodLike.issues[].path` from `(string | number)[]` to `PropertyKey[]` to match Zod v4's actual `$ZodIssue.path` type, fixing a nominal TypeScript incompatibility where real Zod schemas did not satisfy `ZodLike` at the type level.

--- a/packages/types/src/types/plugin.ts
+++ b/packages/types/src/types/plugin.ts
@@ -8,8 +8,6 @@
  * TypeScript types from OpenAPI specs during prebuild.
  */
 
-import { z } from 'zod';
-
 /**
  * Minimal structural interface used in place of z.ZodTypeAny / z.ZodSchema
  * in the PrebuildPlugin public API.
@@ -18,13 +16,13 @@ import { z } from 'zod';
  * from bleeding into the published .d.ts. Any real Zod schema satisfies this
  * via duck-typing, so existing implementations are unaffected.
  */
-interface ZodLike {
+export interface ZodLike {
   safeParse(data: unknown):
     | { success: true }
     | {
         success: false;
         error: {
-          issues: Array<{ path: (string | number)[]; message: string }>;
+          issues: Array<{ path: PropertyKey[]; message: string }>;
         };
       };
 }


### PR DESCRIPTION
## Summary

Two type-level fixes to `@stackwright/types` surfaced from plugin author feedback.

### 1. Export `ZodLike`

`ZodLike` was defined but not exported from `@stackwright/types`. Plugin authors writing typed plugin implementations had no way to reference it by name — they were forced to use index-access (`PrebuildPlugin['contentItemSchemas'][number]`) as a workaround.

**Fix:** Added `export` to `interface ZodLike`.

### 2. Widen `ZodLike.issues[].path` to `PropertyKey[]`

`ZodLike.issues[].path` was typed as `(string | number)[]`. Zod v4's `$ZodIssue.path` is `PropertyKey[]` (`string | number | symbol`), creating a nominal TypeScript incompatibility: real Zod schemas did not satisfy `ZodLike` at the type level, even though they worked fine at runtime.

**Fix:** Widened `path` to `PropertyKey[]` to match what Zod v4 actually produces.

### Bonus cleanup

Removed the unused `import { z } from 'zod'` at the top of `plugin.ts` — `z` was never referenced in the file.

## Checklist

- [x] `pnpm format` passed
- [x] `pnpm lint` passed
- [x] `pnpm test` passed
- [x] Changeset included (`.changeset/zodlike-export-path-fix.md`, patch bump for `@stackwright/types`)