### PR TITLE
docs(contributing): add lockfile sync rule to pre-push checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,8 @@ pnpm test:core
 
 **CI enforces linting and formatting. Run these before every push:**
 
+**If you changed any `package.json`:** run `pnpm install` from the repo root and stage the updated `pnpm-lock.yaml` alongside your changes. CI runs with `--frozen-lockfile` and will fail if the lockfile is out of sync with `package.json`.
+
 ```bash
 pnpm format          # Auto-fix Prettier formatting
 pnpm lint            # Check ESLint (warnings are fine, errors are not)


### PR DESCRIPTION
Adds a reminder to the Pre-Push Checklist that changing any `package.json` requires running `pnpm install` from root and committing the updated `pnpm-lock.yaml`. CI runs with `--frozen-lockfile` so a stale lockfile fails every check before any test even runs.

No changeset needed — docs only.