### PR TITLE
fix(types): move CollectionProvider interfaces from collections to types

### DIFF
--- a/.changeset/collection-provider-interfaces-to-types.md
+++ b/.changeset/collection-provider-interfaces-to-types.md
@@ -1,0 +1,15 @@
+---
+"@stackwright/types": minor
+"@stackwright/collections": patch
+"@stackwright/core": patch
+---
+
+Move `CollectionProvider`, `CollectionEntry`, `CollectionListOptions`, and
+`CollectionListResult` interface contracts from `@stackwright/collections` into
+`@stackwright/types`.
+
+`@stackwright/collections` re-exports all four types from `@stackwright/types`
+so existing imports are fully backwards-compatible — no consumer changes required.
+
+This makes the interface contract accessible to Pro packages and other consumers
+without requiring a dependency on any implementing package.

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -27,6 +27,9 @@
     "test:coverage": "vitest run --coverage",
     "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
   },
+  "dependencies": {
+    "@stackwright/types": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.4.0",
     "tsup": "^8.5.1",

--- a/packages/collections/src/index.ts
+++ b/packages/collections/src/index.ts
@@ -2,6 +2,10 @@
  * @stackwright/collections
  *
  * CollectionProvider interface and file-backed implementation.
+ * The interface contract lives in @stackwright/types so Pro providers
+ * (OpenAPI, Contentful, Sanity, etc.) can implement it without depending
+ * on this package.
+ *
  * Pro providers (Contentful, Sanity, etc.) implement the same interface
  * in separate packages.
  */
@@ -10,5 +14,5 @@ export type {
   CollectionEntry,
   CollectionListOptions,
   CollectionListResult,
-} from './types';
+} from '@stackwright/types';
 export { FileCollectionProvider } from './file-collection-provider';

--- a/packages/core/src/utils/collectionProviderRegistry.ts
+++ b/packages/core/src/utils/collectionProviderRegistry.ts
@@ -1,4 +1,4 @@
-import type { CollectionProvider } from '@stackwright/collections';
+import type { CollectionProvider } from '@stackwright/types';
 
 let provider: CollectionProvider | null = null;
 

--- a/packages/core/test/utils/collectionProviderRegistry.test.ts
+++ b/packages/core/test/utils/collectionProviderRegistry.test.ts
@@ -4,7 +4,7 @@ import {
   getCollectionProvider,
 } from '../../src/utils/collectionProviderRegistry';
 import { clearCollectionProvider } from '../../src/utils/collectionProviderRegistry';
-import type { CollectionProvider } from '@stackwright/collections';
+import type { CollectionProvider } from '@stackwright/types';
 
 function makeMockProvider(overrides: Partial<CollectionProvider> = {}): CollectionProvider {
   return {

--- a/packages/types/src/types/collection-provider.ts
+++ b/packages/types/src/types/collection-provider.ts
@@ -1,0 +1,44 @@
+/**
+ * CollectionProvider — the core runtime interface contract for Stackwright collections.
+ *
+ * Every data backend (file-based, S3, Contentful, Sanity, OpenAPI, etc.)
+ * implements this interface. Swapping backends is a one-line registration
+ * change; the YAML content and rendering layer never change.
+ *
+ * These interfaces live in @stackwright/types so they are accessible to both
+ * OSS packages and Pro packages without creating a dependency on any
+ * implementing package.
+ */
+
+export interface CollectionEntry {
+  slug: string;
+  [key: string]: unknown;
+}
+
+export interface CollectionListOptions {
+  /** Maximum number of entries to return. */
+  limit?: number;
+  /** Number of entries to skip (for pagination). */
+  offset?: number;
+  /** Field name to sort by. Prefix with `-` for descending (e.g. `-date`). */
+  sort?: string;
+  /** Exact-match filters. Keys are field names, values are expected values. */
+  filter?: Record<string, unknown>;
+}
+
+export interface CollectionListResult {
+  entries: CollectionEntry[];
+  /** Total matching entries before limit/offset — enables pagination. */
+  total: number;
+}
+
+export interface CollectionProvider {
+  /** List entries in a collection with optional filtering, sorting, and pagination. */
+  list(collection: string, opts?: CollectionListOptions): Promise<CollectionListResult>;
+
+  /** Get a single entry by slug. Returns null if not found. */
+  get(collection: string, slug: string): Promise<CollectionEntry | null>;
+
+  /** List available collection names. */
+  collections(): Promise<string[]>;
+}

--- a/packages/types/src/types/index.ts
+++ b/packages/types/src/types/index.ts
@@ -7,6 +7,7 @@ export * from './navigation';
 export * from './layout';
 export * from './enums';
 export * from './collection';
+export * from './collection-provider';
 export * from './plugin';
 export * from './secrets';
 export * from './secret-detection';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,10 @@ importers:
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/collections:
+    dependencies:
+      '@stackwright/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@types/node':
         specifier: ^24.1.0


### PR DESCRIPTION
## What

Moves `CollectionProvider`, `CollectionEntry`, `CollectionListOptions`, and `CollectionListResult` from `@stackwright/collections/src/types.ts` into a new `@stackwright/types/src/types/collection-provider.ts`.

## Why

These are interface *contracts* — the shape of what every backend must implement. Having them in an implementing package (`@stackwright/collections`) created an implicit dependency: anything that wanted to type-check against the interface had to depend on the implementation package, even if it never used `FileCollectionProvider`.

Moving them to `@stackwright/types` means:
- OSS: `@stackwright/core`'s registry imports from `@stackwright/types` directly (no more `devDependency` on `collections`)
- Pro: `@stackwright-pro/openapi` can implement `CollectionProvider` by depending on `@stackwright/types` instead of `@stackwright/collections`
- Future Pro types package can extend the interface cleanly

## Backwards compatibility

`@stackwright/collections` re-exports all four types from `@stackwright/types` — existing `import { CollectionProvider } from '@stackwright/collections'` imports continue to work without any changes.

## Files changed
- `packages/types/src/types/collection-provider.ts` — new file, interface definitions
- `packages/types/src/types/index.ts` — re-exports new file
- `packages/collections/src/index.ts` — re-exports from `@stackwright/types`
- `packages/collections/package.json` — adds `@stackwright/types` dependency
- `packages/core/src/utils/collectionProviderRegistry.ts` — import updated
- `packages/core/test/utils/collectionProviderRegistry.test.ts` — import updated