### PR TITLE
docs(claude): always shell out for current date — never guess

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Commit early and often at logical checkpoints.
 
 ## Commands
 
+> **⚠️ Always use `date` for the current date.**
+> Never guess or hard-code a date in documentation, commit messages, changelogs, or coordination files.
+> Run `date` (or `date -I` for `YYYY-MM-DD` format) in the terminal and use the value it returns.
+
 ```bash
 # Install dependencies
 pnpm install


### PR DESCRIPTION
## What
Adds a prominent callout at the top of the `## Commands` section in `CLAUDE.md` instructing agents to always run `date` (or `date -I`) to get the current date rather than guessing or hard-coding it.

## Why
During PR #408 review, dates were written as `2025-07-25` when the actual date was `2026-05-11`. Shelling out for the real date is a one-liner and eliminates the entire class of error.

## Change
- `CLAUDE.md`: added ⚠️ blockquote under `## Commands`