### PR TITLE
fix(publish): remove prepublishOnly workspace: guard

### DIFF
--- a/.changeset/remove-workspace-prepublish-guard.md
+++ b/.changeset/remove-workspace-prepublish-guard.md
@@ -1,0 +1,20 @@
+---
+"@stackwright/build-scripts": patch
+"@stackwright/ui-shadcn": patch
+"@stackwright/mcp": patch
+"@stackwright/sbom-generator": patch
+"@stackwright/core": patch
+"@stackwright/nextjs": patch
+"@stackwright/icons": patch
+"@stackwright/hooks-registry": patch
+"@stackwright/types": patch
+"launch-stackwright": patch
+"@stackwright/collections": patch
+"@stackwright/maplibre": patch
+"@stackwright/themes": patch
+"@stackwright/scaffold-core": patch
+"@stackwright/cli": patch
+"@stackwright/otters": patch
+---
+
+Remove `prepublishOnly` workspace: specifier guard that conflicted with `pnpm publish`'s automatic `workspace:*` → semver resolution. The guard checked the local `package.json` for `workspace:*` entries and rejected them, but `pnpm publish` rewrites those specifiers inside the tarball at publish time without modifying the local file — so the guard always produced false positives and blocked all publishes.

--- a/packages/build-scripts/package.json
+++ b/packages/build-scripts/package.json
@@ -25,7 +25,7 @@
         "build": "tsup",
         "dev": "tsup --watch",
         "test": "vitest run",
-        "prepublishOnly": "pnpm run build && node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\"",
+        "prepublishOnly": "pnpm run build",
         "test:coverage": "vitest run --coverage"
     },
     "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,8 +28,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@inquirer/prompts": "^8.4.3",

--- a/packages/collections/package.json
+++ b/packages/collections/package.json
@@ -24,8 +24,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@stackwright/types": "workspace:*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
         "test": "vitest",
         "test:run": "vitest run",
         "test:coverage": "vitest run --coverage",
-        "prepublishOnly": "npm run build && node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+        "prepublishOnly": "npm run build"
     },
     "dependencies": {
         "@stackwright/themes": "workspace:*",

--- a/packages/hooks-registry/package.json
+++ b/packages/hooks-registry/package.json
@@ -26,8 +26,7 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
-        "test": "vitest run",
-        "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+        "test": "vitest run"
     },
     "devDependencies": {
         "@types/node": "^25.6.2",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -25,8 +25,7 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "lucide-react": "^1.8.0"

--- a/packages/launch-stackwright/package.json
+++ b/packages/launch-stackwright/package.json
@@ -23,8 +23,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest run",
-    "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+    "test": "vitest run"
   },
   "dependencies": {
     "@stackwright/cli": "workspace:*",

--- a/packages/maplibre/package.json
+++ b/packages/maplibre/package.json
@@ -26,8 +26,7 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "maplibre-gl": "^5.24.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -26,7 +26,7 @@
         "dev": "tsup --watch",
         "test": "vitest run",
         "test:watch": "vitest",
-        "prepublishOnly": "pnpm build && node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\"",
+        "prepublishOnly": "pnpm build",
         "test:coverage": "vitest run --coverage"
     },
     "dependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -25,7 +25,7 @@
         "dev": "tsup --watch",
         "test": "vitest run",
         "test:run": "vitest run",
-        "prepublishOnly": "npm run build && node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\"",
+        "prepublishOnly": "npm run build",
         "test:coverage": "vitest run --coverage"
     },
     "dependencies": {

--- a/packages/otters/package.json
+++ b/packages/otters/package.json
@@ -8,8 +8,7 @@
     "url": "https://github.com/Per-Aspera-LLC/stackwright"
   },
   "scripts": {
-    "postinstall": "node scripts/install-agents.js",
-    "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+    "postinstall": "node scripts/install-agents.js"
   },
   "files": [
     "src",

--- a/packages/sbom-generator/package.json
+++ b/packages/sbom-generator/package.json
@@ -26,7 +26,7 @@
         "test": "vitest",
         "test:run": "vitest run",
         "test:coverage": "vitest run --coverage",
-        "prepublishOnly": "npm run build && node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+        "prepublishOnly": "npm run build"
     },
     "dependencies": {
         "js-yaml": "^4.1.0",

--- a/packages/scaffold-core/package.json
+++ b/packages/scaffold-core/package.json
@@ -23,8 +23,7 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
-        "test": "vitest run",
-        "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+        "test": "vitest run"
     },
     "dependencies": {
         "@stackwright/hooks-registry": "workspace:*"

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -25,8 +25,7 @@
     "dev": "tsup --watch",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "js-yaml": "^4",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,8 +29,7 @@
         "generate-schemas": "tsx src/generate-schemas.ts",
         "dev": "tsup --watch",
         "test": "vitest run",
-        "test:coverage": "vitest run --coverage",
-        "prepublishOnly": "node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\""
+        "test:coverage": "vitest run --coverage"
     },
     "dependencies": {
         "@stackwright/themes": "workspace:*",

--- a/packages/ui-shadcn/package.json
+++ b/packages/ui-shadcn/package.json
@@ -25,7 +25,7 @@
     "build": "tsup && pnpm build:css",
     "build:css": "tailwindcss -i src/styles.css -o dist/styles.css --minify",
     "dev": "tsup --watch",
-    "prepublishOnly": "pnpm build && node -e \"const p=require('./package.json');const fields=[...Object.values(p.dependencies||{}),...Object.values(p.peerDependencies||{})];const bad=fields.filter(v=>String(v).includes('workspace:'));if(bad.length){console.error('ERR: workspace: specifiers found in publishable dep fields:',bad);process.exit(1)}\"",
+    "prepublishOnly": "pnpm build",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

The `prepublishOnly` lifecycle script in all 16 publishable packages contained a guard that scanned `dependencies` and `peerDependencies` for `workspace:*` specifiers and exited with code 1 if any were found.

This conflicts with how `pnpm publish` works: pnpm rewrites `workspace:*` → resolved semver **inside the generated tarball** at publish time, without ever touching the local `package.json`. The guard reads the local file, always finds unresolved specifiers, and always fails — blocking every publish.

## Fix

- Packages where `prepublishOnly` was **guard only**: key removed entirely
- Packages where `prepublishOnly` was **build step + guard**: guard stripped, build step preserved

## Affected packages

All 16 publishable packages in the monorepo.

## Testing

Push to `dev` will trigger the prerelease workflow — successful alpha publish confirms the fix.