### PR TITLE
fix(types): complete Phase 1 cleanup of types-hierarchy-refactor

### DIFF
--- a/.changeset/collections-types-cleanup.md
+++ b/.changeset/collections-types-cleanup.md
@@ -1,0 +1,13 @@
+---
+"@stackwright/collections": patch
+---
+
+chore(collections): remove duplicate CollectionProvider definitions
+
+`file-collection-provider.ts` now imports `CollectionProvider`, `CollectionEntry`,
+`CollectionListOptions`, and `CollectionListResult` directly from `@stackwright/types`
+rather than from the local `./types` file.
+
+`types.ts` is converted to a re-export shim so any unexpected downstream imports
+remain backward-compatible. This completes the Phase 1 cleanup from the
+types-hierarchy-refactor.

--- a/.changeset/generate-agent-docs-interfaces.md
+++ b/.changeset/generate-agent-docs-interfaces.md
@@ -1,0 +1,15 @@
+---
+"@stackwright/cli": patch
+---
+
+feat(cli): generate-agent-docs now emits an interface contracts table
+
+A new auto-generated section in AGENTS.md documents the TypeScript interface
+contracts defined in `@stackwright/types`:
+
+- CollectionProvider, CollectionEntry, CollectionListOptions, CollectionListResult
+- ScaffoldHookContext, ScaffoldHook, HookHandler, ScaffoldHookType
+
+The section is delimited by `<!-- stackwright:interface-table:start/end -->` markers
+and updated by `pnpm stackwright -- generate-agent-docs` alongside the existing
+content-type-table. This completes Phase 1 step 8 of the types-hierarchy-refactor.

--- a/.changeset/hookhandler-reexport.md
+++ b/.changeset/hookhandler-reexport.md
@@ -1,0 +1,15 @@
+---
+"@stackwright/hooks-registry": patch
+"@stackwright/scaffold-core": patch
+---
+
+fix(scaffold-core): export HookHandler type from hooks-registry and scaffold-core
+
+`HookHandler` is the canonical type alias for scaffold hook handler functions,
+defined in `@stackwright/types`. It was re-exported by `hooks-registry/src/hooks.ts`
+but not forwarded through `index.ts`, making it unavailable via the public package
+import paths.
+
+Both `@stackwright/hooks-registry` and `@stackwright/scaffold-core` now re-export
+`HookHandler` alongside the other scaffold hook types. This completes Phase 1 step 4
+of the types-hierarchy-refactor.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,29 @@ The YAML key is the key used inside `content_items` entries. All types inherit `
 **TypographyVariant values:** `h1` `h2` `h3` `h4` `h5` `h6` `subtitle1` `subtitle2` `body1` `body2` `caption` `button` `overline`
 <!-- stackwright:content-type-table:end -->
 
+### Interface Contracts
+
+**AGENTS: This table is auto-generated from `@stackwright/types`. Run `pnpm stackwright -- generate-agent-docs` to regenerate. Do NOT edit the content between the markers manually.**
+
+<!-- stackwright:interface-table:start -->
+All interface contracts are defined in `@stackwright/types` and re-exported from `@stackwright/collections`, `@stackwright/hooks-registry`, and `@stackwright/scaffold-core` for backward compatibility.
+
+| Interface / Type | Kind | Fields / Signature |
+|---|---|---|
+| `CollectionProvider` | interface | `list(collection, opts?)` (Promise<CollectionListResult>), `get(collection, slug)` (Promise<CollectionEntry | null>), `collections()` (Promise<string[]>) |
+| `CollectionEntry` | interface | `slug` (string), `[key: string]` (unknown) |
+| `CollectionListOptions` | interface | `limit`? (number), `offset`? (number), `sort`? (string), `filter`? (Record<string, unknown>) |
+| `CollectionListResult` | interface | `entries` (CollectionEntry[]), `total` (number) |
+| `ScaffoldHookContext` | interface | `targetDir` (string), `projectName` (string), `siteTitle` (string), `themeId` (string), `packageJson` (Record<string, unknown>), `dependencyMode` ('workspace' | 'standalone'), `codePuppyConfig`? (Record<string, unknown>), `pages`? (string[]), `install`? (boolean), `[key: string]`? (unknown) |
+| `ScaffoldHook` | interface | `type` (ScaffoldHookType), `name` (string), `handler` (HookHandler), `priority`? (number), `critical`? (boolean) |
+| `HookHandler` | type | `(context: ScaffoldHookContext)` (Promise<void> | void) |
+| `ScaffoldHookType` | type | `values` ('preScaffold' | 'preInstall' | 'postInstall' | 'postScaffold') |
+
+**Import paths (all equivalent):**
+- `CollectionProvider` — `@stackwright/types` · `@stackwright/collections`
+- `ScaffoldHookContext`, `ScaffoldHook`, `HookHandler`, `ScaffoldHookType` — `@stackwright/types` · `@stackwright/hooks-registry` · `@stackwright/scaffold-core`
+<!-- stackwright:interface-table:end -->
+
 ### Dark Mode & Color Preferences
 
 Stackwright has first-class dark mode and cookie-based preference persistence:

--- a/examples/stackwright-docs/AGENTS.md
+++ b/examples/stackwright-docs/AGENTS.md
@@ -52,6 +52,29 @@ The YAML key is the key used inside `content_items` entries. All types inherit `
 **TypographyVariant values:** `h1` `h2` `h3` `h4` `h5` `h6` `subtitle1` `subtitle2` `body1` `body2` `caption` `button` `overline`
 <!-- stackwright:content-type-table:end -->
 
+### Interface Contracts
+
+**AGENTS: This table is auto-generated from `@stackwright/types`. Run `pnpm stackwright -- generate-agent-docs` to regenerate. Do NOT edit the content between the markers manually.**
+
+<!-- stackwright:interface-table:start -->
+All interface contracts are defined in `@stackwright/types` and re-exported from `@stackwright/collections`, `@stackwright/hooks-registry`, and `@stackwright/scaffold-core` for backward compatibility.
+
+| Interface / Type | Kind | Fields / Signature |
+|---|---|---|
+| `CollectionProvider` | interface | `list(collection, opts?)` (Promise<CollectionListResult>), `get(collection, slug)` (Promise<CollectionEntry | null>), `collections()` (Promise<string[]>) |
+| `CollectionEntry` | interface | `slug` (string), `[key: string]` (unknown) |
+| `CollectionListOptions` | interface | `limit`? (number), `offset`? (number), `sort`? (string), `filter`? (Record<string, unknown>) |
+| `CollectionListResult` | interface | `entries` (CollectionEntry[]), `total` (number) |
+| `ScaffoldHookContext` | interface | `targetDir` (string), `projectName` (string), `siteTitle` (string), `themeId` (string), `packageJson` (Record<string, unknown>), `dependencyMode` ('workspace' | 'standalone'), `codePuppyConfig`? (Record<string, unknown>), `pages`? (string[]), `install`? (boolean), `[key: string]`? (unknown) |
+| `ScaffoldHook` | interface | `type` (ScaffoldHookType), `name` (string), `handler` (HookHandler), `priority`? (number), `critical`? (boolean) |
+| `HookHandler` | type | `(context: ScaffoldHookContext)` (Promise<void> | void) |
+| `ScaffoldHookType` | type | `values` ('preScaffold' | 'preInstall' | 'postInstall' | 'postScaffold') |
+
+**Import paths (all equivalent):**
+- `CollectionProvider` — `@stackwright/types` · `@stackwright/collections`
+- `ScaffoldHookContext`, `ScaffoldHook`, `HookHandler`, `ScaffoldHookType` — `@stackwright/types` · `@stackwright/hooks-registry` · `@stackwright/scaffold-core`
+<!-- stackwright:interface-table:end -->
+
 ## Development Commands
 
 ```bash

--- a/packages/cli/src/commands/generate-agent-docs.ts
+++ b/packages/cli/src/commands/generate-agent-docs.ts
@@ -36,6 +36,9 @@ export interface GenerateAgentDocsResult {
 const START_MARKER = '<!-- stackwright:content-type-table:start -->';
 const END_MARKER = '<!-- stackwright:content-type-table:end -->';
 
+const INTERFACE_START_MARKER = '<!-- stackwright:interface-table:start -->';
+const INTERFACE_END_MARKER = '<!-- stackwright:interface-table:end -->';
+
 // ---------------------------------------------------------------------------
 // Schema name registry — maps Zod schema object references to display names.
 // When zodSchemaToTypeString encounters one of these schemas (after resolving
@@ -255,6 +258,148 @@ function generateTypographyLine(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Interface contracts table — documents the TypeScript interface contracts
+// defined in @stackwright/types. These are not Zod schemas so they are
+// described via a static config rather than runtime introspection.
+// ---------------------------------------------------------------------------
+
+interface InterfaceField {
+  name: string;
+  type: string;
+  optional: boolean;
+}
+
+interface InterfaceContract {
+  name: string;
+  kind: 'interface' | 'type';
+  description: string;
+  fields: InterfaceField[];
+}
+
+const INTERFACE_CONTRACTS: InterfaceContract[] = [
+  {
+    name: 'CollectionProvider',
+    kind: 'interface',
+    description:
+      'Core runtime contract for Stackwright data backends. Every backend (file, S3, Contentful, OpenAPI, etc.) implements this interface.',
+    fields: [
+      { name: 'list(collection, opts?)', type: 'Promise<CollectionListResult>', optional: false },
+      { name: 'get(collection, slug)', type: 'Promise<CollectionEntry | null>', optional: false },
+      { name: 'collections()', type: 'Promise<string[]>', optional: false },
+    ],
+  },
+  {
+    name: 'CollectionEntry',
+    kind: 'interface',
+    description: 'A single entry returned by a CollectionProvider.',
+    fields: [
+      { name: 'slug', type: 'string', optional: false },
+      { name: '[key: string]', type: 'unknown', optional: false },
+    ],
+  },
+  {
+    name: 'CollectionListOptions',
+    kind: 'interface',
+    description: 'Options for filtering, sorting and paginating collection list results.',
+    fields: [
+      { name: 'limit', type: 'number', optional: true },
+      { name: 'offset', type: 'number', optional: true },
+      { name: 'sort', type: 'string', optional: true },
+      { name: 'filter', type: 'Record<string, unknown>', optional: true },
+    ],
+  },
+  {
+    name: 'CollectionListResult',
+    kind: 'interface',
+    description: 'Result shape returned by CollectionProvider.list().',
+    fields: [
+      { name: 'entries', type: 'CollectionEntry[]', optional: false },
+      { name: 'total', type: 'number', optional: false },
+    ],
+  },
+  {
+    name: 'ScaffoldHookContext',
+    kind: 'interface',
+    description:
+      "Mutable context object passed to every scaffold hook handler. Earlier hooks' changes are visible to later hooks.",
+    fields: [
+      { name: 'targetDir', type: 'string', optional: false },
+      { name: 'projectName', type: 'string', optional: false },
+      { name: 'siteTitle', type: 'string', optional: false },
+      { name: 'themeId', type: 'string', optional: false },
+      { name: 'packageJson', type: 'Record<string, unknown>', optional: false },
+      { name: 'dependencyMode', type: "'workspace' | 'standalone'", optional: false },
+      { name: 'codePuppyConfig', type: 'Record<string, unknown>', optional: true },
+      { name: 'pages', type: 'string[]', optional: true },
+      { name: 'install', type: 'boolean', optional: true },
+      { name: '[key: string]', type: 'unknown', optional: true },
+    ],
+  },
+  {
+    name: 'ScaffoldHook',
+    kind: 'interface',
+    description:
+      'A single scaffold hook registration. Pass to registerScaffoldHook() from @stackwright/scaffold-core.',
+    fields: [
+      { name: 'type', type: 'ScaffoldHookType', optional: false },
+      { name: 'name', type: 'string', optional: false },
+      { name: 'handler', type: 'HookHandler', optional: false },
+      { name: 'priority', type: 'number', optional: true },
+      { name: 'critical', type: 'boolean', optional: true },
+    ],
+  },
+  {
+    name: 'HookHandler',
+    kind: 'type',
+    description: 'Function signature for scaffold hook handlers.',
+    fields: [
+      { name: '(context: ScaffoldHookContext)', type: 'Promise<void> | void', optional: false },
+    ],
+  },
+  {
+    name: 'ScaffoldHookType',
+    kind: 'type',
+    description:
+      'Lifecycle point union. Execution order: preScaffold → preInstall → postInstall → postScaffold.',
+    fields: [
+      {
+        name: 'values',
+        type: "'preScaffold' | 'preInstall' | 'postInstall' | 'postScaffold'",
+        optional: false,
+      },
+    ],
+  },
+];
+
+function generateInterfaceTable(): string {
+  const lines = [
+    'All interface contracts are defined in `@stackwright/types` and re-exported from `@stackwright/collections`, `@stackwright/hooks-registry`, and `@stackwright/scaffold-core` for backward compatibility.',
+    '',
+    '| Interface / Type | Kind | Fields / Signature |',
+    '|---|---|---|',
+  ];
+
+  for (const contract of INTERFACE_CONTRACTS) {
+    const fieldList = contract.fields
+      .map((f) => {
+        const namePart = f.optional ? `\`${f.name}\`?` : `\`${f.name}\``;
+        return `${namePart} (${f.type})`;
+      })
+      .join(', ');
+    lines.push(`| \`${contract.name}\` | ${contract.kind} | ${fieldList} |`);
+  }
+
+  lines.push('');
+  lines.push('**Import paths (all equivalent):**');
+  lines.push('- `CollectionProvider` — `@stackwright/types` · `@stackwright/collections`');
+  lines.push(
+    '- `ScaffoldHookContext`, `ScaffoldHook`, `HookHandler`, `ScaffoldHookType` — `@stackwright/types` · `@stackwright/hooks-registry` · `@stackwright/scaffold-core`'
+  );
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
 // Build the full generated block (content between the markers)
 // ---------------------------------------------------------------------------
 
@@ -280,19 +425,21 @@ function buildGeneratedBlock(): string {
 // File update logic
 // ---------------------------------------------------------------------------
 
-function updateAgentsMd(
+function updateMarkerBlock(
   filePath: string,
+  startMarker: string,
+  endMarker: string,
   newBlock: string
 ): 'updated' | 'up-to-date' | 'no-markers' | 'not-found' {
   if (!fs.existsSync(filePath)) return 'not-found';
 
   const current = fs.readFileSync(filePath, 'utf-8');
-  const startIdx = current.indexOf(START_MARKER);
-  const endIdx = current.indexOf(END_MARKER);
+  const startIdx = current.indexOf(startMarker);
+  const endIdx = current.indexOf(endMarker);
 
   if (startIdx === -1 || endIdx === -1) return 'no-markers';
 
-  const before = current.slice(0, startIdx + START_MARKER.length);
+  const before = current.slice(0, startIdx + startMarker.length);
   const after = current.slice(endIdx);
   const updated = `${before}\n${newBlock}\n${after}`;
 
@@ -302,12 +449,20 @@ function updateAgentsMd(
   return 'updated';
 }
 
+function updateAgentsMd(
+  filePath: string,
+  newBlock: string
+): 'updated' | 'up-to-date' | 'no-markers' | 'not-found' {
+  return updateMarkerBlock(filePath, START_MARKER, END_MARKER, newBlock);
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 export function generateAgentDocs(root: string = process.cwd()): GenerateAgentDocsResult {
   const newBlock = buildGeneratedBlock();
+  const newInterfaceBlock = generateInterfaceTable();
 
   const targetFiles = [
     path.join(root, 'AGENTS.md'),
@@ -319,19 +474,47 @@ export function generateAgentDocs(root: string = process.cwd()): GenerateAgentDo
   const errors: string[] = [];
 
   for (const filePath of targetFiles) {
+    // Update content-type-table
     const result = updateAgentsMd(filePath, newBlock);
     switch (result) {
       case 'updated':
-        filesUpdated.push(filePath);
+        if (!filesUpdated.includes(filePath)) filesUpdated.push(filePath);
         break;
       case 'up-to-date':
-        filesSkipped.push(filePath);
+        if (!filesUpdated.includes(filePath) && !filesSkipped.includes(filePath))
+          filesSkipped.push(filePath);
         break;
       case 'no-markers':
-        errors.push(`Markers not found in: ${filePath}`);
+        errors.push(`Content-type-table markers not found in: ${filePath}`);
         break;
       case 'not-found':
         errors.push(`File not found: ${filePath}`);
+        break;
+    }
+
+    // Update interface-table
+    const interfaceResult = updateMarkerBlock(
+      filePath,
+      INTERFACE_START_MARKER,
+      INTERFACE_END_MARKER,
+      newInterfaceBlock
+    );
+    switch (interfaceResult) {
+      case 'updated': {
+        if (!filesUpdated.includes(filePath)) filesUpdated.push(filePath);
+        // Remove from skipped if it was added there by the first pass
+        const skipIdx = filesSkipped.indexOf(filePath);
+        if (skipIdx !== -1) filesSkipped.splice(skipIdx, 1);
+        break;
+      }
+      case 'up-to-date':
+        // already tracked correctly
+        break;
+      case 'no-markers':
+        errors.push(`Interface-table markers not found in: ${filePath}`);
+        break;
+      case 'not-found':
+        // already reported above
         break;
     }
   }

--- a/packages/collections/src/file-collection-provider.ts
+++ b/packages/collections/src/file-collection-provider.ts
@@ -5,7 +5,7 @@ import type {
   CollectionEntry,
   CollectionListOptions,
   CollectionListResult,
-} from './types';
+} from '@stackwright/types';
 
 /**
  * File-backed CollectionProvider.

--- a/packages/collections/src/types.ts
+++ b/packages/collections/src/types.ts
@@ -1,40 +1,15 @@
 /**
  * CollectionProvider — the core abstraction for Stackwright collections.
  *
- * Every data backend (file-based, S3, Contentful, Sanity, OpenAPI, etc.)
- * implements this interface. Swapping backends is a one-line registration
- * change; the YAML content and rendering layer never change.
+ * Interface contracts have moved to @stackwright/types so they are accessible
+ * to Pro packages and other consumers without a dependency on this package.
+ * This file re-exports them for any internal consumers that import from ./types.
+ *
+ * Do NOT re-add type definitions here — edit @stackwright/types instead.
  */
-
-export interface CollectionEntry {
-  slug: string;
-  [key: string]: unknown;
-}
-
-export interface CollectionListOptions {
-  /** Maximum number of entries to return. */
-  limit?: number;
-  /** Number of entries to skip (for pagination). */
-  offset?: number;
-  /** Field name to sort by. Prefix with `-` for descending (e.g. `-date`). */
-  sort?: string;
-  /** Exact-match filters. Keys are field names, values are expected values. */
-  filter?: Record<string, unknown>;
-}
-
-export interface CollectionListResult {
-  entries: CollectionEntry[];
-  /** Total matching entries before limit/offset — enables pagination. */
-  total: number;
-}
-
-export interface CollectionProvider {
-  /** List entries in a collection with optional filtering, sorting, and pagination. */
-  list(collection: string, opts?: CollectionListOptions): Promise<CollectionListResult>;
-
-  /** Get a single entry by slug. Returns null if not found. */
-  get(collection: string, slug: string): Promise<CollectionEntry | null>;
-
-  /** List available collection names. */
-  collections(): Promise<string[]>;
-}
+export type {
+  CollectionProvider,
+  CollectionEntry,
+  CollectionListOptions,
+  CollectionListResult,
+} from '@stackwright/types';

--- a/packages/hooks-registry/src/index.ts
+++ b/packages/hooks-registry/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Types re-export
-export type { ScaffoldHook, ScaffoldHookType, ScaffoldHookContext } from './hooks';
+export type { ScaffoldHook, ScaffoldHookType, ScaffoldHookContext, HookHandler } from './hooks';
 
 // Registry functions
 export {

--- a/packages/scaffold-core/src/index.ts
+++ b/packages/scaffold-core/src/index.ts
@@ -11,6 +11,7 @@ export type {
   ScaffoldHook,
   ScaffoldHookType,
   ScaffoldHookContext,
+  HookHandler,
 } from '@stackwright/hooks-registry';
 
 // Re-export all registry functions


### PR DESCRIPTION
## Summary

Three items from Phase 1 of the types-hierarchy-refactor (#408) that were identified as incomplete during a post-merge audit.

## Changes

### 1. `collections/src/types.ts` zombie removed
The original `CollectionProvider` interface definitions were left in place after being moved to `@stackwright/types`. `types.ts` is now a re-export shim so any downstream imports remain backward-compatible. `file-collection-provider.ts` now imports directly from `@stackwright/types`.

### 2. `HookHandler` forwarded through `hooks-registry` and `scaffold-core`  
`HookHandler` was canonical in `@stackwright/types` and re-exported by `hooks-registry/src/hooks.ts` but not forwarded through `index.ts`, making `import type { HookHandler } from '@stackwright/hooks-registry'` fail silently. Both `@stackwright/hooks-registry` and `@stackwright/scaffold-core` now re-export it alongside the other scaffold hook types.

### 3. `generate-agent-docs` extended with interface contracts table (Phase 1 step 8)
A new auto-generated section in both `AGENTS.md` files documents the TypeScript interface contracts from `@stackwright/types`. The section is delimited by `<!-- stackwright:interface-table:start/end -->` markers and updated by `pnpm stackwright -- generate-agent-docs` alongside the existing content-type-table.

## Testing

- `pnpm test` — 864/864 passing
- `pnpm build` — all 15 packages clean
- `pnpm stackwright -- generate-agent-docs` — both AGENTS.md files confirmed in sync

## Changesets

- `collections-types-cleanup` — patch for `@stackwright/collections`  
- `hookhandler-reexport` — patch for `@stackwright/hooks-registry`, `@stackwright/scaffold-core`
- `generate-agent-docs-interfaces` — patch for `@stackwright/cli`