### PR TITLE
fix(ci): remove [skip ci] from automated commit messages

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -48,7 +48,7 @@ jobs:
             git config user.name "github-actions"
             git config user.email "github-actions@github.com"
             git add .changeset/pre.json
-            git commit -m "chore: enter prerelease mode [skip ci]"
+            git commit -m "chore: enter prerelease mode"
             git push origin dev
             fi
 
@@ -66,7 +66,7 @@ jobs:
       - name: Push changes back to dev
         run: |
           git add .
-          git commit -m "chore: bump prerelease versions [skip ci]" || echo "No changes to commit"
+          git commit -m "chore: bump prerelease versions" || echo "No changes to commit"
           git push origin dev
 
       - name: Publish prereleases with tag 'alpha'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Use startsWith (not contains) to check ONLY the commit title for [skip ci].
-    # Squash merges embed individual commit messages in the body, and automated
-    # commits (prerelease bumps, etc.) include [skip ci] — which would incorrectly
-    # suppress the release workflow if we used contains() on the full body.
+    # startsWith guards against the release workflow re-triggering on its own
+    # version bump commit. Must stay in sync with the commit message below.
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'push' &&
-         !startsWith(github.event.head_commit.message, 'chore: version packages for release [skip ci]')) }}
+         !startsWith(github.event.head_commit.message, 'chore: version packages for release')) }}
     steps:
       - name: Generate PerAsperaCI token
         id: app-token
@@ -120,7 +118,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "chore: version packages for release [skip ci]" || echo "No changes to commit"
+          git commit -m "chore: version packages for release" || echo "No changes to commit"
           git push origin main
 
       - name: Back-merge into dev
@@ -141,7 +139,7 @@ jobs:
           if [ ! -f ".changeset/pre.json" ]; then
             pnpm changeset pre enter alpha
             git add .changeset/pre.json
-            git commit -m "chore: re-enter prerelease mode after back-merge [skip ci]"
+            git commit -m "chore: re-enter prerelease mode after back-merge"
           fi
           # Force push is required after a rebase to rewrite dev's remote history.
           git push origin dev --force-with-lease


### PR DESCRIPTION
## Problem

Automated commits on `dev` used the GitHub skip-ci flag (`[skip-ci]`) in their messages to prevent CI reruns. However, GitHub scans the **full commit message body**, not just the subject line. Standard merge commits to `main` auto-populate their body with a list of individual PR commits — so any skip-ci flag in a dev commit message leaks into the main merge commit body and suppresses **all** workflow triggers on that push, before any job-level `if` conditions can run.

**Confirmed:** PRs #410 and #419 both show zero workflow runs on `main` (not even skipped entries) because their merge commit bodies contained skip-ci lines from automated dev commits.

## Fix

Remove skip-ci flags from all five automated commit messages across both workflow files. Loop prevention is handled entirely by the existing job-level `if` conditions, which is the correct mechanism.

Also updates the `startsWith` guard in `release.yml` to match the new commit message string, so the loop-prevention logic stays in sync.

## Changes

- `prerelease.yml`: removed skip-ci flag from `chore: bump prerelease versions` and `chore: enter prerelease mode` commits
- `release.yml`: removed skip-ci flag from `chore: version packages for release` and `chore: re-enter prerelease mode after back-merge` commits; updated job-level `if` condition to match

## Testing

The next dev→main merge after this lands will confirm workflows trigger correctly. `workflow_dispatch` on `release.yml` from `main` can also verify end-to-end.