### PR TITLE
fix(deps): scope js-yaml override to restore changesets compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 	    "uuid": ">=14.0.0",
 	    "fast-uri": ">=3.1.2",
 	    "js-yaml": ">=4.1.1",
+	    "read-yaml-file>js-yaml": "^3",
 	    "postcss": ">=8.5.10"
         },
         "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   uuid: '>=14.0.0'
   fast-uri: '>=3.1.2'
   js-yaml: '>=4.1.1'
+  read-yaml-file>js-yaml: ^3
   postcss: '>=8.5.10'
 
 importers:
@@ -3226,6 +3227,9 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4570,6 +4574,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -5570,6 +5578,9 @@ packages:
   split-string@3.1.0:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -8628,6 +8639,10 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -10143,6 +10158,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -10897,7 +10917,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.1.1
+      js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -11285,6 +11305,8 @@ snapshots:
   split-string@3.1.0:
     dependencies:
       extend-shallow: 3.0.2
+
+  sprintf-js@1.0.3: {}
 
   stable-hash@0.0.5: {}
 


### PR DESCRIPTION
## Problem

PR `bbf46a43` (security overrides) added `"js-yaml": ">=4.1.1"` to `pnpm.overrides`, forcing js-yaml v4 globally. `@changesets/cli@2.31.0` has a transitive dep `read-yaml-file@1.1.0` that calls `yaml.safeLoad()`, which was removed in js-yaml v4.

This broke `pnpm changeset version` in CI, causing both prerelease runs triggered by PRs #420 and #421 to fail:
```
Error: Function yaml.safeLoad is removed in js-yaml 4.
Use yaml.load instead, which is now safe by default.
```

## Fix

pnpm's `package>dependency` override syntax scopes a version constraint to one specific package's dep resolution. Adding `"read-yaml-file>js-yaml": "^3"` gives `read-yaml-file` its own js-yaml v3 without affecting any other package. All Stackwright packages stay on `>=4.1.1` per the security fix.

## Verification

Confirmed via module resolution inspection:
- `read-yaml-file` resolves js-yaml to its own nested `node_modules/read-yaml-file/node_modules/js-yaml` at **v3.14.2** with `safeLoad` intact ✅
- Global `js-yaml` remains **v4.1.1** (security-fix version) ✅
- `require('read-yaml-file')` loads cleanly with no errors ✅

## No changeset needed

`pnpm.overrides` is lockfile infrastructure — no published package API changes.