### PR TITLE
fix(ci): resolve js-yaml override conflict breaking release workflow

### DIFF
--- a/.changeset/fix-js-yaml-override-conflict.md
+++ b/.changeset/fix-js-yaml-override-conflict.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/cli": patch
+---
+
+Fix js-yaml version override conflict in pnpm overrides that caused `yaml.safeLoad is removed` errors when running `changeset pre exit` in CI. The global `js-yaml: >=4.1.1` override was stomping the scoped `read-yaml-file>js-yaml: ^3` override, forcing js-yaml v4 into read-yaml-file which doesn't support it.

--- a/package.json
+++ b/package.json
@@ -93,11 +93,10 @@
             "@hono/node-server": ">=1.19.13",
             "basic-ftp": ">=5.3.1",
             "express-rate-limit": ">=8.2.2",
-	    "uuid": ">=14.0.0",
-	    "fast-uri": ">=3.1.2",
-	    "js-yaml": ">=4.1.1",
-	    "read-yaml-file>js-yaml": "^3",
-	    "postcss": ">=8.5.10"
+            "uuid": ">=14.0.0",
+            "fast-uri": ">=3.1.2",
+            "read-yaml-file>js-yaml": "^3",
+            "postcss": ">=8.5.10"
         },
         "onlyBuiltDependencies": [
             "@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,6 @@ overrides:
   express-rate-limit: '>=8.2.2'
   uuid: '>=14.0.0'
   fast-uri: '>=3.1.2'
-  js-yaml: '>=4.1.1'
   read-yaml-file>js-yaml: ^3
   postcss: '>=8.5.10'
 
@@ -123,7 +122,7 @@ importers:
         specifier: ^7.1.0
         version: 7.3.0
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4.1.1
         version: 4.1.1
       lucide-react:
         specifier: ^1.8.0
@@ -181,7 +180,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4.1.0
         version: 4.1.1
       zod:
         specifier: ^4.3.6
@@ -215,7 +214,7 @@ importers:
         specifier: ^11.3
         version: 11.3.4
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4.1.0
         version: 4.1.1
       playwright:
         specifier: ^1.52.0
@@ -283,7 +282,7 @@ importers:
         specifier: ^7.1.0
         version: 7.3.0
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4.1.0
         version: 4.1.1
       prismjs:
         specifier: ^1.30.0
@@ -520,7 +519,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4.1.0
         version: 4.1.1
     devDependencies:
       '@swc/core':
@@ -565,7 +564,7 @@ importers:
   packages/sbom-generator:
     dependencies:
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4.1.0
         version: 4.1.1
       zod:
         specifier: ^4.3.6
@@ -603,7 +602,7 @@ importers:
   packages/themes:
     dependencies:
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4
         version: 4.1.1
       zod:
         specifier: ^4.3.6
@@ -646,7 +645,7 @@ importers:
         specifier: workspace:*
         version: link:../themes
       js-yaml:
-        specifier: '>=4.1.1'
+        specifier: ^4.1.0
         version: 4.1.1
       zod:
         specifier: ^4.3.6
@@ -3227,6 +3226,9 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4571,6 +4573,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -5571,6 +5577,9 @@ packages:
   split-string@3.1.0:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -8629,6 +8638,10 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -10144,6 +10157,11 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -10898,7 +10916,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.1.1
+      js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -11286,6 +11304,8 @@ snapshots:
   split-string@3.1.0:
     dependencies:
       extend-shallow: 3.0.2
+
+  sprintf-js@1.0.3: {}
 
   stable-hash@0.0.5: {}
 


### PR DESCRIPTION
## Problem

The release workflow was failing at the `Exit prerelease mode` step with:

```
🦋  error Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead
```

## Root Cause

PR #423 added a scoped override `"read-yaml-file>js-yaml": "^3"` to fix this, but left the conflicting global override in place:

```json
"js-yaml": ">=4.1.1",           ← global: forced ALL js-yaml to v4, including for read-yaml-file
"read-yaml-file>js-yaml": "^3"  ← scoped: silently lost — global wins
```

In pnpm's override resolution, the global `js-yaml: >=4.1.1` override stomped the scoped one, so `read-yaml-file` still got js-yaml v4 (which removed `yaml.safeLoad`). The lockfile snapshot confirmed it: `read-yaml-file@1.1.0` was still resolving `js-yaml: 4.1.1` even after #423.

Additionally, PR #423 introduced inconsistent tab indentation in `package.json` for the affected override entries.

## Fix

- Removed the conflicting global `"js-yaml": ">=4.1.1"` override. All workspace packages already pull js-yaml v4 from their own `package.json` dependencies — the global override was redundant and harmful here.
- The scoped `"read-yaml-file>js-yaml": "^3"` override now correctly applies, giving `read-yaml-file` its own nested `js-yaml@3.14.2`.
- Fixed tab → 4-space indentation for the entries added by #423.
- Ran `pnpm install` to regenerate the lockfile with the correct snapshot.

## Verification

After `pnpm install`, `read-yaml-file@1.1.0` resolves to `js-yaml@3.14.2` ✅

```
read-yaml-file@1.1.0:
  dependencies:
    js-yaml: 3.14.2  ✅  (was 4.1.1 💀)
```

`pnpm changeset --version` → `2.31.0` ✅
`node -e "require('@changesets/cli')"` → no errors ✅
`read-yaml-file` has its own nested `node_modules/js-yaml@3.14.2` ✅