### PR TITLE
fix(ci): handle modify/delete conflict on pre.json during back-merge rebase

### DIFF
--- a/.changeset/fix-back-merge-pre-json-conflict.md
+++ b/.changeset/fix-back-merge-pre-json-conflict.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/cli": patch
+---
+
+Fix back-merge into dev failing with a modify/delete conflict on `.changeset/pre.json` during rebase. The release workflow deletes this file via `changeset pre exit`, but dev's alpha-bump commits still reference it. The rebase now explicitly resolves the conflict by accepting main's deletion and continuing.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,13 @@ jobs:
           #
           # -X ours: when conflicts arise (e.g. version numbers in package.json),
           # prefer main's graduated stable versions over dev's stale alpha versions.
-          git rebase origin/main -X ours
+          git rebase origin/main -X ours || {
+            # Expected modify/delete conflict on .changeset/pre.json:
+            # release deleted it via `changeset pre exit`, but dev's alpha-bump
+            # commit still referenced it. Accept main's deletion and continue.
+            git rm -f .changeset/pre.json 2>/dev/null || true
+            GIT_EDITOR=true git rebase --continue
+          }
           # Re-enter prerelease mode so the next dev push produces alphas.
           if [ ! -f ".changeset/pre.json" ]; then
             pnpm changeset pre enter alpha


### PR DESCRIPTION
## Problem

The `Back-merge into dev` step in the release workflow fails with:

```
CONFLICT (modify/delete): .changeset/pre.json deleted in HEAD and modified in ffce9aa (chore: bump prerelease versions)
error: could not apply ffce9aa... chore: bump prerelease versions
```

## Root Cause

`git rebase origin/main -X ours` auto-resolves *content* conflicts but not *modify/delete* conflicts. When the release exits prerelease mode (`changeset pre exit` deletes `.changeset/pre.json` on main), then tries to rebase dev's alpha-bump commits (which modified `pre.json`) on top — git halts with a structural conflict.

The `-X ours` flag is helpless here: it only applies to three-way content merges, not to structural modify/delete cases. Git stops, demands manual intervention, and exits 1 in CI.

## Fix

Added an explicit conflict handler after the rebase command. If the rebase fails, it removes `.changeset/pre.json` (accepting main's intentional deletion) and calls `git rebase --continue`. `GIT_EDITOR=true` prevents git from trying to open an interactive editor for the commit message in the non-interactive CI environment.

```bash
git rebase origin/main -X ours || {
  # Expected modify/delete conflict on .changeset/pre.json:
  # release deleted it via `changeset pre exit`, but dev's alpha-bump
  # commit still referenced it. Accept main's deletion and continue.
  git rm -f .changeset/pre.json 2>/dev/null || true
  GIT_EDITOR=true git rebase --continue
}
```

The existing `if [ ! -f ".changeset/pre.json" ]` block immediately after correctly re-enters prerelease mode once the rebase completes cleanly.

## Related

Follows on from #424 (js-yaml override conflict fix) — publish now succeeds ✅, this unblocks the back-merge step.