### PR TITLE
fix(ci): loop over pre.json conflicts during back-merge rebase

### DIFF
--- a/.changeset/fix-back-merge-loop.md
+++ b/.changeset/fix-back-merge-loop.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/cli": patch
+---
+
+Upgrade the back-merge rebase conflict handler from a one-shot block to a loop. Dev can accumulate multiple alpha-bump commits that all modified `.changeset/pre.json` — the previous one-shot `||{ }` only resolved the first conflict. The loop now runs until all pre.json conflicts are resolved or an unexpected conflict is encountered.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,13 +134,19 @@ jobs:
           #
           # -X ours: when conflicts arise (e.g. version numbers in package.json),
           # prefer main's graduated stable versions over dev's stale alpha versions.
-          git rebase origin/main -X ours || {
-            # Expected modify/delete conflict on .changeset/pre.json:
-            # release deleted it via `changeset pre exit`, but dev's alpha-bump
-            # commit still referenced it. Accept main's deletion and continue.
-            git rm -f .changeset/pre.json 2>/dev/null || true
-            GIT_EDITOR=true git rebase --continue
-          }
+          git rebase origin/main -X ours || true
+          while [ -d ".git/rebase-merge" ]; do
+            if git status --porcelain | grep -q "pre.json"; then
+              # Expected: pre.json was deleted by `changeset pre exit` on main,
+              # but dev's alpha-bump commits still modified it. Accept the deletion.
+              git rm -f .changeset/pre.json 2>/dev/null || true
+              GIT_EDITOR=true git rebase --continue || true
+            else
+              echo "Unexpected rebase conflict — aborting"
+              git rebase --abort
+              exit 1
+            fi
+          done
           # Re-enter prerelease mode so the next dev push produces alphas.
           if [ ! -f ".changeset/pre.json" ]; then
             pnpm changeset pre enter alpha


### PR DESCRIPTION
## Problem

PR #426 fixed the first `.changeset/pre.json` modify/delete conflict during back-merge rebase, but `dev` can have **multiple** alpha-bump commits that all touched `pre.json`. The one-shot `||{ }` handler resolved the first conflict and continued — only to hit the same conflict on the next commit and exit 1.

Observed in run [25963196021](https://github.com/Per-Aspera-LLC/stackwright/actions/runs/25963196021):
```
Rebasing (1/4) → CONFLICT on ffce9aa (.changeset/pre.json)
||{ } fires → git rm + rebase --continue ✅
Rebasing (3/4) → CONFLICT on d7c4dfe (.changeset/pre.json)  ← no handler left 💀
error: could not apply d7c4dfe... chore: bump prerelease versions
```

## Fix

Replaced the one-shot handler with a `while [ -d ".git/rebase-merge" ]` loop that keeps resolving `pre.json` conflicts and calling `git rebase --continue` until the rebase completes. Unexpected conflicts (anything other than `pre.json`) still abort and exit 1 so we don't silently swallow real problems.

```bash
git rebase origin/main -X ours || true
while [ -d ".git/rebase-merge" ]; do
  if git status --porcelain | grep -q "pre.json"; then
    git rm -f .changeset/pre.json 2>/dev/null || true
    GIT_EDITOR=true git rebase --continue || true
  else
    echo "Unexpected rebase conflict — aborting"
    git rebase --abort
    exit 1
  fi
done
```

## Follows on from
- #424 — js-yaml override conflict
- #426 — first pre.json conflict handler (one-shot)