### PR TITLE
fix(a11y): tabindex on code blocks, skip link, fix timeline heading level

### DIFF
--- a/packages/core/src/components/base/CodeBlock.tsx
+++ b/packages/core/src/components/base/CodeBlock.tsx
@@ -66,6 +66,7 @@ export function CodeBlock({ code, language, lineNumbers = false, background }: C
           </div>
         )}
         <pre
+          tabIndex={0}
           style={{
             margin: 0,
             padding: theme.spacing.md,

--- a/packages/core/src/components/narrative/Timeline.tsx
+++ b/packages/core/src/components/narrative/Timeline.tsx
@@ -74,7 +74,7 @@ export function Timeline(content: TimelineContent) {
                   boxShadow: getThemeShadow(theme, 'md'),
                 }}
               >
-                <h4
+                <h3
                   style={{
                     color: theme.colors.primary,
                     fontWeight: 'bold',
@@ -83,7 +83,7 @@ export function Timeline(content: TimelineContent) {
                   }}
                 >
                   {item.year}
-                </h4>
+                </h3>
                 <p style={{ color: theme.colors.text, margin: 0 }}>{item.event}</p>
               </div>
             </div>

--- a/packages/core/src/components/structural/DefaultPageLayout.tsx
+++ b/packages/core/src/components/structural/DefaultPageLayout.tsx
@@ -54,6 +54,53 @@ export default function DefaultPageLayout(pageContent: PageContent) {
 
   return (
     <div style={{ display: 'flex', minHeight: '100vh' }}>
+      <a
+        href="#main-content"
+        style={{
+          position: 'absolute',
+          left: '-9999px',
+          top: 'auto',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+          zIndex: 9999,
+        }}
+        onFocus={(e) => {
+          Object.assign(e.currentTarget.style, {
+            left: '50%',
+            transform: 'translateX(-50%)',
+            top: '1rem',
+            width: 'auto',
+            height: 'auto',
+            overflow: 'visible',
+            padding: '0.5rem 1.25rem',
+            backgroundColor: '#000',
+            color: '#fff',
+            borderRadius: '4px',
+            textDecoration: 'none',
+            fontWeight: 'bold',
+            fontSize: '0.875rem',
+          });
+        }}
+        onBlur={(e) => {
+          Object.assign(e.currentTarget.style, {
+            left: '-9999px',
+            top: 'auto',
+            width: '1px',
+            height: '1px',
+            overflow: 'hidden',
+            transform: '',
+            padding: '',
+            backgroundColor: '',
+            color: '',
+            borderRadius: '',
+            fontWeight: '',
+            fontSize: '',
+          });
+        }}
+      >
+        Skip to main content
+      </a>
       {resolvedSidebar && (
         <NavSidebar
           navigationItems={resolvedSidebar.navigation}
@@ -65,6 +112,7 @@ export default function DefaultPageLayout(pageContent: PageContent) {
         />
       )}
       <main
+        id="main-content"
         style={{
           flex: 1,
           minWidth: 0,

--- a/packages/core/src/components/structural/PageLayout.tsx
+++ b/packages/core/src/components/structural/PageLayout.tsx
@@ -84,6 +84,53 @@ export default function PageLayout({ pageContent, siteConfig }: PageLayoutProps)
         color: theme.colors.text,
       }}
     >
+      <a
+        href="#main-content"
+        style={{
+          position: 'absolute',
+          left: '-9999px',
+          top: 'auto',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+          zIndex: 9999,
+        }}
+        onFocus={(e) => {
+          Object.assign(e.currentTarget.style, {
+            left: '50%',
+            transform: 'translateX(-50%)',
+            top: '1rem',
+            width: 'auto',
+            height: 'auto',
+            overflow: 'visible',
+            padding: '0.5rem 1.25rem',
+            backgroundColor: '#000',
+            color: '#fff',
+            borderRadius: '4px',
+            textDecoration: 'none',
+            fontWeight: 'bold',
+            fontSize: '0.875rem',
+          });
+        }}
+        onBlur={(e) => {
+          Object.assign(e.currentTarget.style, {
+            left: '-9999px',
+            top: 'auto',
+            width: '1px',
+            height: '1px',
+            overflow: 'hidden',
+            transform: '',
+            padding: '',
+            backgroundColor: '',
+            color: '',
+            borderRadius: '',
+            fontWeight: '',
+            fontSize: '',
+          });
+        }}
+      >
+        Skip to main content
+      </a>
       <TopAppBar
         title={config.appBar.titleText}
         logo={config.appBar.logo}
@@ -105,7 +152,7 @@ export default function PageLayout({ pageContent, siteConfig }: PageLayoutProps)
           />
         )}
 
-        <main style={{ flex: 1, minWidth: 0, backgroundColor }}>
+        <main id="main-content" style={{ flex: 1, minWidth: 0, backgroundColor }}>
           {renderContent(pageContent, { contentItemsOnly: true })}
         </main>
       </div>


### PR DESCRIPTION
## Summary

Three surgical a11y fixes identified in CI accessibility audit (run [#25964031984](https://github.com/Per-Aspera-LLC/stackwright/actions/runs/25964031984)).

### Changes

- **`CodeBlock.tsx`** — adds `tabIndex={0}` to the `<pre>` element so scrollable code regions are keyboard-reachable (fixes axe `scrollable-region-focusable` rule, affects all 6 pages)
- **`PageLayout.tsx` + `DefaultPageLayout.tsx`** — adds a visually-hidden skip-to-main-content link as the first focusable element on every page; adds `id="main-content"` to the `<main>` element (WCAG 2.4.1 Bypass Blocks)
- **`Timeline.tsx`** — changes item year headings from `<h4>` to `<h3>` to prevent h2→h4 heading hierarchy skips when a timeline has no section heading (WCAG 1.3.1)

### What this does NOT touch
Color contrast issues are addressed in the follow-up PR (fix/a11y-batch-2-contrast) branched from this one.

### Testing
```bash
pnpm --filter @stackwright/e2e exec playwright test tests/a11y/
```