### PR TITLE
fix(a11y): surface-aware syntax highlighting, fix dark mode heading and button contrast

### DIFF
--- a/examples/stackwright-docs/stackwright.yml
+++ b/examples/stackwright-docs/stackwright.yml
@@ -77,7 +77,7 @@ customTheme:
     text: "#FFFFFF"
     textSecondary: "#B0BEC5"
   darkColors:
-    primary: "#D97706"   # Amber 600 - darker for dark mode
+    primary: "#92400e"   # Amber 800 — WCAG AA compliant on light dark-mode backgrounds (~5.8:1 on #F5F5F5)
     secondary: "#0288D1"
     accent: "#F59E0B"   # Amber 500
     background: "#FDFDFD"

--- a/packages/core/src/components/base/CodeBlock.tsx
+++ b/packages/core/src/components/base/CodeBlock.tsx
@@ -3,6 +3,7 @@ import { CodeBlockContent } from '@stackwright/types';
 import { useSafeTheme, useSafeColorMode } from '../../hooks/useSafeTheme';
 import { resolveBackground } from '../../utils/resolveBackground';
 import { highlightCode, getTokenColor, HighlightToken } from '../../utils/prismHighlighter';
+import { hexToRgb, getLuminance } from '../../utils/colorUtils';
 
 /**
  * Split a flat token list into per-line groups so each line can be
@@ -25,7 +26,9 @@ function splitTokensByLine(tokens: HighlightToken[]): HighlightToken[][] {
 export function CodeBlock({ code, language, lineNumbers = false, background }: CodeBlockContent) {
   const theme = useSafeTheme();
   const resolvedColorMode = useSafeColorMode();
-  const isDark = resolvedColorMode === 'dark';
+  const surfaceRgb = hexToRgb(theme.colors.surface);
+  const surfaceLuminance = surfaceRgb ? getLuminance(surfaceRgb.r, surfaceRgb.g, surfaceRgb.b) : 0;
+  const isDarkSurface = surfaceLuminance < 0.179;
 
   const tokens = highlightCode(code.trimEnd(), language);
   const tokenLines = splitTokensByLine(tokens);
@@ -100,7 +103,7 @@ export function CodeBlock({ code, language, lineNumbers = false, background }: C
               <span>
                 {lineTokens.length > 0
                   ? lineTokens.map((t, j) => {
-                      const color = getTokenColor(t.type, isDark);
+                      const color = getTokenColor(t.type, isDarkSurface);
                       return color ? (
                         <span key={j} style={{ color }}>
                           {t.content}

--- a/packages/core/src/components/base/ThemedButton.tsx
+++ b/packages/core/src/components/base/ThemedButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ButtonContent } from '@stackwright/types';
 import { useSafeTheme } from '../../hooks/useSafeTheme';
-import { getHoverColor, resolveColor } from '../../utils/colorUtils';
+import { getHoverColor, resolveColor, getBetterTextColor } from '../../utils/colorUtils';
 import { Media } from '../media/Media';
 
 interface ThemedButtonProps {
@@ -40,7 +40,9 @@ export function ThemedButton({ button, className }: ThemedButtonProps) {
     : theme.colors.primary;
   const buttonTextColor = button.textColor
     ? resolveColor(button.textColor, theme.colors)
-    : theme.colors.text;
+    : button.variant === undefined || button.variant === 'contained'
+      ? getBetterTextColor('#FFFFFF', '#1A1A1A', buttonColor)
+      : theme.colors.text;
   const hoverColor = getHoverColor(buttonColor);
   const buttonSize = button.variantSize || 'medium';
 


### PR DESCRIPTION
## Summary

Color contrast fixes from the CI accessibility audit. Stacks on top of #430 — merge that first.

### Root cause

The docs theme is dark-mode-first: its **light mode** has a dark navy surface (`#1A2C46`) and its **dark mode** has a near-white surface (`#F5F5F5`). The syntax highlighter was choosing token palettes based on `colorMode === 'dark'`, which is exactly backwards for this theme, causing 30–42 failing elements per page.

### Changes

- **`CodeBlock.tsx`** — replaces `colorMode === 'dark'` with a luminance check on `theme.colors.surface`. Token palette now adapts to the actual rendered surface color regardless of how the theme names its modes. Uses existing `hexToRgb` + `getLuminance` from `colorUtils.ts`.
- **`stackwright.yml`** — changes `darkColors.primary` from `#D97706` (amber-600, ~2.77:1 on light backgrounds) to `#92400e` (amber-800, ~5.82:1) — WCAG AA compliant on the `#F5F5F5` surface used in dark mode.
- **`ThemedButton.tsx`** — contained-variant buttons now auto-select text color (dark vs light) using `getBetterTextColor()` based on the resolved background, fixing the `#fff` on `#FCC03E` issue (was 1.64:1, now uses dark text for sufficient contrast).

### Remaining known issues
- Keyboard traps (video on /otter-raft, details/summary on /showcase) — tracked separately
- Carousel keyboard flakiness — tracked separately