### PR TITLE
fix(build-scripts,docs): wire registerSiteIcons, fix slug filter, add Layout→LayoutTemplate alias

### DIFF
--- a/.changeset/icon-layout-alias-fix.md
+++ b/.changeset/icon-layout-alias-fix.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/build-scripts": patch
+---
+
+Add `Layout → LayoutTemplate` to `LEGACY_MUI_ICON_ALIASES` in the icon manifest generator. `Layout` was renamed to `LayoutTemplate` in lucide-react v1.x; without this alias the prebuild emitted `import { Layout } from 'lucide-react'` which does not exist and crashes the build.

--- a/examples/stackwright-docs/pages/[slug].tsx
+++ b/examples/stackwright-docs/pages/[slug].tsx
@@ -9,7 +9,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
     const dir = path.join(process.cwd(), "public", "stackwright-content");
     const slugs = fs
         .readdirSync(dir)
-        .filter(f => f.endsWith(".json") && f !== "_site.json" && f !== "_root.json" && f !== "search-index.json" && f !== "_font-links.json")
+        .filter(f => f.endsWith(".json") && !f.startsWith("_") && f !== "search-index.json")
         .map(f => f.replace(/\.json$/, ""));
     return {
         paths: slugs.map(slug => ({ params: { slug } })),
@@ -26,7 +26,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     // Validate slug against known content files to prevent path traversal
     const knownSlugs = fs
         .readdirSync(dir)
-        .filter(f => f.endsWith(".json") && f !== "_site.json" && f !== "_root.json" && f !== "search-index.json" && f !== "_font-links.json")
+        .filter(f => f.endsWith(".json") && !f.startsWith("_") && f !== "search-index.json")
         .map(f => f.replace(/\.json$/, ""));
     const slug = knownSlugs.includes(rawSlug) ? rawSlug : null;
 

--- a/examples/stackwright-docs/pages/_app.tsx
+++ b/examples/stackwright-docs/pages/_app.tsx
@@ -1,12 +1,12 @@
 import type { AppProps } from "next/app";
-import { registerDefaultIcons } from "@stackwright/icons";
+import { registerSiteIcons } from "../stackwright-generated/icons";
 import { registerNextJSComponents } from "@stackwright/nextjs";
 import { registerShadcnComponents } from "@stackwright/ui-shadcn";
 import "@stackwright/ui-shadcn/styles.css";
 
 // Register Next.js adapter components (Image, Link, Router, Route), icons, and UI
 registerNextJSComponents();
-registerDefaultIcons();
+registerSiteIcons();
 registerShadcnComponents();
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/examples/stackwright-docs/stackwright-generated/icons.ts
+++ b/examples/stackwright-docs/stackwright-generated/icons.ts
@@ -3,7 +3,7 @@
 //
 // This file is safe to commit. It will be updated whenever your YAML content changes.
 
-import { Bot, Box, Camera, CircleAlert, CircleCheck, Code, Code2, FileCode, FilePlus, FileText, FlaskConical, Globe, Hammer, Image, Info, Layers, Layout, Map, Moon, Package, Palette, Plug, Rocket, Search, Shield, ShieldCheck, Smartphone, Sparkles, Sun, Terminal, TriangleAlert, Zap } from 'lucide-react';
+import { Bot, Box, Camera, CircleAlert, CircleCheck, Code, Code2, FileCode, FilePlus, FileText, FlaskConical, Globe, Hammer, Image, Info, Layers, LayoutTemplate, Map, Moon, Package, Palette, Plug, Rocket, Search, Shield, ShieldCheck, Smartphone, Sparkles, Sun, Terminal, TriangleAlert, Zap } from 'lucide-react';
 import {
   BlueSkyIcon,
   StackwrightIcon,
@@ -28,7 +28,7 @@ const siteIconPreset: Record<string, React.ComponentType<any>> = {
   Image,
   Info,
   Layers,
-  Layout,
+  'Layout': LayoutTemplate, // legacy MUI alias — candidate for deprecation
   Map,
   Moon,
   Package,

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -398,6 +398,7 @@ const LEGACY_MUI_ICON_ALIASES: Record<string, string> = {
   // Lucide renamed-icon backward compat
   CheckCircle: 'CircleCheck',
   AlertTriangle: 'TriangleAlert',
+  Layout: 'LayoutTemplate',
 };
 
 /**

--- a/packages/themes/src/themeLoader.ts
+++ b/packages/themes/src/themeLoader.ts
@@ -114,7 +114,6 @@ export class ThemeLoader {
    */
   static loadThemeFromYaml(yamlContent: string): Theme {
     try {
-       
       const yaml = require('js-yaml') as typeof import('js-yaml');
       const theme = yaml.load(yamlContent) as Theme;
       this.themes.set(theme.name, theme);


### PR DESCRIPTION
## Summary

Three interconnected bugs introduced when the icon manifest feature (`generateIconManifest`) landed in `@stackwright/build-scripts`:

### Bug 1 — `_icon-manifest.json` routed as a page
`getStaticPaths` in `pages/[slug].tsx` had an explicit exclusion list for internal JSON files (`_site.json`, `_root.json`, etc.) but was missing `_icon-manifest.json`. Next.js was trying to build a page at route `/_icon-manifest` and failing.

**Fix:** Replaced the brittle allowlist with `!f.startsWith('_')` — future-proof against any new internal `_*.json` the prebuild adds. Applied to both `getStaticPaths` and `getStaticProps`.

### Bug 2 — Icon imports not wired to the generated manifest
`_app.tsx` was still calling `registerDefaultIcons()` (the ~43-icon fallback preset) instead of `registerSiteIcons()` from `stackwright-generated/icons`. The generated file existed on disk but was never imported. Icons used in YAML that are absent from the default preset (`Smartphone`, `Plug`, `Hammer`, `Map`, `FileCode`, `FilePlus`, `Camera`, `Terminal`, `Box`, `Search`, `Image`, `Layout`) were not rendering.

**Fix:** Replaced `registerDefaultIcons()` with `registerSiteIcons()` from `../stackwright-generated/icons`.

### Bug 3 — `Layout` import crashes the build
`pages/architecture/content.yml` uses `src: Layout`. `Layout` was renamed to `LayoutTemplate` in lucide-react v1.x. The `LEGACY_MUI_ICON_ALIASES` map already handles `CheckCircle → CircleCheck` and `AlertTriangle → TriangleAlert` but was missing `Layout → LayoutTemplate`. The prebuild was emitting `import { Layout } from 'lucide-react'` which doesn't exist in v1.x and crashes webpack.

**Fix:** Added `Layout: 'LayoutTemplate'` to `LEGACY_MUI_ICON_ALIASES` in `prebuild.ts`. Also manually patched the committed `stackwright-generated/icons.ts` snapshot so the build is unblocked immediately without requiring a `pnpm predev` run.

## Files changed
- `packages/build-scripts/src/prebuild.ts` — add alias
- `examples/stackwright-docs/pages/_app.tsx` — wire generated icons
- `examples/stackwright-docs/pages/[slug].tsx` — future-proof slug filter
- `examples/stackwright-docs/stackwright-generated/icons.ts` — fix committed snapshot

## Checklist
- [x] Changeset added (`@stackwright/build-scripts` patch)
- [x] `pnpm format` passed
- [x] `pnpm lint` passed (0 errors, 6 pre-existing warnings)
- [x] `pnpm test` passed (897 tests, 52 test files — all green)
- [x] Targets `dev` branch