### PR TITLE
fix(sbom) + feat(prebuild): SBOM dir fix, pnpm v9 parsing, theme.yml split (swp-cp3, swp-z21)

### DIFF
--- a/.changeset/feat-theme-split-z21.md
+++ b/.changeset/feat-theme-split-z21.md
@@ -1,0 +1,5 @@
+---
+"@stackwright/build-scripts": minor
+---
+
+feat(prebuild): support `stackwright.theme.yml` sidecar config for isolated theme configuration — merges `themeName`, `customTheme`, and `fonts` on top of `stackwright.yml`, preventing multi-otter clobbering between Theme Otter and Page Otter

--- a/.changeset/fix-sbom-cp3.md
+++ b/.changeset/fix-sbom-cp3.md
@@ -1,0 +1,6 @@
+---
+"@stackwright/build-scripts": patch
+"@stackwright/sbom-generator": patch
+---
+
+fix(sbom): write SBOM files to `.stackwright/sbom/` instead of project root; fix pnpm lockfile v9 parsing that produced 0 dependencies in all SBOMs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,40 @@ public/stackwright-content/
 - `stackwright_get_page` — accepts optional `locale` param; falls back to default with a note if locale file absent
 - `stackwright_list_pages` — shows available locales per page: `  /about  —  About Us  [en, fr]`
 
+### Theme Config File Split (`stackwright.theme.yml`)
+
+The prebuild supports an optional `stackwright.theme.yml` sidecar file for isolating theme configuration from the main `stackwright.yml`.
+
+**Purpose:** Prevents multi-otter clobbering. Theme Otter owns `stackwright.theme.yml`; Page Otter owns `stackwright.yml`. They never touch each other's files.
+
+**Keys merged from `stackwright.theme.yml`:**
+- `themeName` — name of the active theme
+- `customTheme` — full custom theme object (typography, colors, spacing, etc.)
+- `fonts` — font loading strategy
+
+**All other keys in `stackwright.theme.yml` are silently ignored** — only the three theme keys above are merged.
+
+**Resolution order (higher wins):**
+1. `stackwright.theme.yml` theme keys (override)
+2. `stackwright.yml` theme keys (base)
+
+**Example:**
+```yaml
+# stackwright.theme.yml — owned by Theme Otter
+themeName: "ocean-dark"
+fonts:
+  strategy: bundle
+customTheme:
+  typography:
+    fontFamily:
+      primary: "Inter, sans-serif"
+      secondary: "JetBrains Mono, monospace"
+```
+
+**Both files are required to form a valid config** — validation runs on the merged result, so errors in either file surface at build time.
+
+**Extension:** Both `.yml` and `.yaml` extensions are supported.
+
 ### Content Type Reference
 
 **AGENTS: This table is auto-generated from the live Zod schemas. Run `pnpm stackwright -- generate-agent-docs` to regenerate. Do NOT edit the content between the markers manually.**

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -1326,6 +1326,41 @@ function auditIntegrationAuthSecrets(config: unknown): void {
 
 // -- Main -------------------------------------------------------------------
 
+/** The keys in siteConfig that belong to the theme split file. */
+const THEME_OVERRIDE_KEYS = ['themeName', 'customTheme', 'fonts'] as const;
+
+/**
+ * Find the theme override file in the project root.
+ * Returns the file path if found, or null.
+ * Checks stackwright.theme.yml and stackwright.theme.yaml.
+ */
+function findThemeOverrideFile(projectRoot: string): string | null {
+  for (const name of ['stackwright.theme.yml', 'stackwright.theme.yaml']) {
+    const p = path.join(projectRoot, name);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+/**
+ * Merge theme-specific keys from themeConfig into baseConfig.
+ * Only THEME_OVERRIDE_KEYS are merged — all other keys in themeConfig are ignored.
+ * Theme file values win (override base config values for the same key).
+ * Returns a new object; does not mutate inputs.
+ */
+function mergeThemeOverride(
+  baseConfig: Record<string, unknown>,
+  themeConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...baseConfig };
+  for (const key of THEME_OVERRIDE_KEYS) {
+    if (themeConfig[key] !== undefined) {
+      result[key] = themeConfig[key];
+    }
+  }
+  return result;
+}
+
 /** Find locale-specific site config files in projectRoot (e.g. stackwright.fr.yml → { locale: 'fr', filePath }) */
 function findLocaleConfigFiles(projectRoot: string): Array<{ locale: string; filePath: string }> {
   const results: Array<{ locale: string; filePath: string }> = [];
@@ -1381,7 +1416,21 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
   }
 
   console.log('\nProcessing site config...');
-  const rawConfig = yaml.load(fs.readFileSync(siteConfigFile, 'utf8'));
+  const rawSiteConfig = yaml.load(fs.readFileSync(siteConfigFile, 'utf8'));
+
+  // Apply theme override from stackwright.theme.yml (if present).
+  // Only themeName, customTheme, and fonts are merged; all other keys are ignored.
+  // This allows Theme Otter and Page Otter to own separate files without clobbering.
+  const themeOverrideFile = findThemeOverrideFile(projectRoot);
+  const rawConfig = themeOverrideFile
+    ? mergeThemeOverride(
+        rawSiteConfig as Record<string, unknown>,
+        yaml.load(fs.readFileSync(themeOverrideFile, 'utf8')) as Record<string, unknown>
+      )
+    : rawSiteConfig;
+  if (themeOverrideFile) {
+    console.log('  Applied theme override from stackwright.theme.yml');
+  }
 
   const siteValidation = siteConfigSchema.safeParse(rawConfig);
   if (!siteValidation.success) {

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -1648,14 +1648,15 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
     const sbomStrict = process.argv.includes('--sbom-strict');
     try {
       const { createSBOM } = await import('@stackwright/sbom-generator');
+      const sbomOutputDir = path.join(projectRoot, '.stackwright', 'sbom');
       const sbom = await createSBOM({
         projectRoot,
         formats: ['spdx', 'cyclonedx', 'build-manifest'],
         includeDevDependencies: false,
         includePeerDependencies: true,
-        outputDir: path.join(projectRoot, '.stackwright', 'sbom'),
+        outputDir: sbomOutputDir,
       });
-      await sbom.writeTo(projectRoot);
+      await sbom.writeTo(sbomOutputDir);
       console.log('\n  [OK] SBOM generated: .stackwright/sbom/');
     } catch (error) {
       if (sbomStrict) {

--- a/packages/build-scripts/test/prebuild-theme-split.test.ts
+++ b/packages/build-scripts/test/prebuild-theme-split.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for stackwright.theme.yml config file split (swp-z21).
+ *
+ * stackwright.theme.yml is an optional sidecar that holds only theme-specific
+ * keys (themeName, customTheme, fonts). prebuild merges these on top of
+ * stackwright.yml before validation so Theme Otter and Page Otter can own
+ * separate files without clobbering each other.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { runPrebuild } from '../src/prebuild';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_SITE_CONFIG = `title: "Test Site"
+appBar:
+  titleText: "Test"
+navigation: []
+`;
+
+const PAGE_CONTENT_YAML = `content:
+  content_items:
+    - type: text_block
+      label: "test"
+      textBlocks:
+        - text: "Hello"
+          textSize: "body1"
+`;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpProject(siteYaml = BASE_SITE_CONFIG): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-theme-split-test-'));
+  fs.writeFileSync(path.join(root, 'stackwright.yml'), siteYaml);
+  const pagesDir = path.join(root, 'pages');
+  fs.mkdirSync(pagesDir, { recursive: true });
+  fs.writeFileSync(path.join(pagesDir, 'content.yml'), PAGE_CONTENT_YAML);
+  return root;
+}
+
+function readSiteJson(root: string): Record<string, unknown> {
+  const p = path.join(root, 'public', 'stackwright-content', '_site.json');
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function cleanup(root: string): void {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('stackwright.theme.yml config split', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = '';
+  });
+  afterEach(() => {
+    if (tmpRoot) cleanup(tmpRoot);
+  });
+
+  it('runs without errors when no stackwright.theme.yml exists (no regression)', async () => {
+    tmpRoot = makeTmpProject();
+    await expect(runPrebuild({ projectRoot: tmpRoot })).resolves.not.toThrow();
+    const site = readSiteJson(tmpRoot);
+    expect(site.title).toBe('Test Site');
+    expect(site.themeName).toBeUndefined();
+  });
+
+  it('merges themeName from stackwright.theme.yml into _site.json', async () => {
+    tmpRoot = makeTmpProject();
+    fs.writeFileSync(path.join(tmpRoot, 'stackwright.theme.yml'), `themeName: "ocean-dark"\n`);
+    await runPrebuild({ projectRoot: tmpRoot });
+    const site = readSiteJson(tmpRoot);
+    expect(site.themeName).toBe('ocean-dark');
+    expect(site.title).toBe('Test Site'); // base config preserved
+  });
+
+  it('merges fonts from stackwright.theme.yml, overriding base config fonts', async () => {
+    tmpRoot = makeTmpProject(BASE_SITE_CONFIG + `fonts:\n  strategy: external\n`);
+    fs.writeFileSync(path.join(tmpRoot, 'stackwright.theme.yml'), `fonts:\n  strategy: bundle\n`);
+    await runPrebuild({ projectRoot: tmpRoot });
+    const site = readSiteJson(tmpRoot);
+    expect((site.fonts as any)?.strategy).toBe('bundle');
+  });
+
+  it('ignores non-theme keys in stackwright.theme.yml (title, navigation, appBar)', async () => {
+    tmpRoot = makeTmpProject();
+    fs.writeFileSync(
+      path.join(tmpRoot, 'stackwright.theme.yml'),
+      `themeName: "sand"\ntitle: "Should Be Ignored"\nnavigation:\n  - label: "Injected"\n    href: "/injected"\n`
+    );
+    await runPrebuild({ projectRoot: tmpRoot });
+    const site = readSiteJson(tmpRoot);
+    expect(site.themeName).toBe('sand');
+    expect(site.title).toBe('Test Site'); // NOT overridden
+    expect(site.navigation).toEqual([]); // NOT overridden
+  });
+
+  it('stackwright.theme.yaml (.yaml extension) is also discovered', async () => {
+    tmpRoot = makeTmpProject();
+    fs.writeFileSync(path.join(tmpRoot, 'stackwright.theme.yaml'), `themeName: "midnight"\n`);
+    await runPrebuild({ projectRoot: tmpRoot });
+    const site = readSiteJson(tmpRoot);
+    expect(site.themeName).toBe('midnight');
+  });
+});

--- a/packages/sbom-generator/src/analyzer.ts
+++ b/packages/sbom-generator/src/analyzer.ts
@@ -61,15 +61,19 @@ export async function analyzeDependencies(options: AnalyzerOptions): Promise<{
     const content = await readFile(lockfilePath, 'utf-8');
     const lockfile = yaml.load(content) as Record<string, unknown>;
 
-    if (lockfile.packages) {
-      debugLog('Lockfile packages found', {
-        count: Object.keys(lockfile.packages as object).length,
+    // pnpm v9 uses 'snapshots' for installed instances (with dep info);
+    // older versions use 'packages' which includes both metadata and deps.
+    // Prefer snapshots if present (v9), fall back to packages.
+    const packagesSource =
+      (lockfile.snapshots as Record<string, LockfilePackage> | undefined) ??
+      (lockfile.packages as Record<string, LockfilePackage> | undefined);
+
+    if (packagesSource) {
+      debugLog('Lockfile packages/snapshots found', {
+        count: Object.keys(packagesSource).length,
       });
 
-      dependencies = parseLockfilePackages(
-        lockfile.packages as Record<string, LockfilePackage>,
-        projectRoot
-      );
+      dependencies = parseLockfilePackages(packagesSource, projectRoot);
     }
   } catch {
     debugLog('Could not read lockfile, using package.json dependencies only');

--- a/packages/sbom-generator/src/normalizers/pnpm.ts
+++ b/packages/sbom-generator/src/normalizers/pnpm.ts
@@ -8,15 +8,17 @@ import { resolve } from 'node:path';
 import yaml from 'js-yaml';
 
 export interface LockfilePackage {
-  /** Resolved version */
-  version: string;
+  /** Resolved version — present in older pnpm lockfile formats; embedded in key for v9+ */
+  version?: string;
+  /** pnpm v9+: resolution info including integrity hash */
+  resolution?: { integrity?: string };
   /** Optional resolved version string */
   resolvedVersion?: string;
   /** Dependencies with version specifiers as keys */
   dependencies?: Record<string, string>;
   /** Peer dependencies */
   peerDependencies?: Record<string, string>;
-  /** Optional integrity hash */
+  /** Optional integrity hash (older formats) */
   integrity?: string;
 }
 
@@ -72,7 +74,40 @@ export async function readPnpmLockfile(projectRoot: string): Promise<{
 }
 
 /**
- * Parse lockfile packages section to extract dependencies
+ * Extract package name and version from a pnpm lockfile key.
+ *
+ * Handles multiple lockfile version formats:
+ *   - v5/v6:  /react@18.0.0  or  /@scope/pkg@1.0.0
+ *   - v9:     react@18.0.0   or  @scope/pkg@1.0.0
+ *   - v9 with peer context: pkg@1.0.0(peer@2.0.0)
+ */
+function extractNameVersionFromKey(key: string): { name: string; version: string } | null {
+  // Strip leading slash (v5/v6 format: /react@18.0.0)
+  let clean = key.startsWith('/') ? key.slice(1) : key;
+
+  // Strip peer context suffix: pkg@1.0.0(peerPkg@peerVer) → pkg@1.0.0
+  // Handle nested parens: pkg@1.0.0(a@1(b@2)) — strip from first top-level '('
+  const parenIdx = clean.indexOf('(');
+  if (parenIdx !== -1) {
+    clean = clean.slice(0, parenIdx);
+  }
+
+  // Split on the LAST '@' to separate name from version
+  // (handles scoped packages like @scope/name@1.0.0 where there are two '@')
+  const lastAt = clean.lastIndexOf('@');
+  if (lastAt <= 0) return null; // No '@' found, or '@' only at position 0 (not a version)
+
+  const name = clean.slice(0, lastAt);
+  const version = clean.slice(lastAt + 1);
+
+  if (!name || !version) return null;
+
+  return { name, version };
+}
+
+/**
+ * Parse lockfile packages section to extract dependencies.
+ * Works with all pnpm lockfile versions (v5, v6, v9).
  */
 export function parseLockfilePackages(
   packages: Record<string, LockfilePackage>,
@@ -80,28 +115,28 @@ export function parseLockfilePackages(
 ): NormalizedDependency[] {
   const result: NormalizedDependency[] = [];
 
-  for (const [path, pkg] of Object.entries(packages)) {
-    // Skip if not a node_modules path
-    if (!path.includes('node_modules/')) continue;
+  for (const [key, pkg] of Object.entries(packages)) {
+    if (!pkg || typeof pkg !== 'object') continue;
 
-    // Extract package name from path
-    const name = extractPackageName(path);
-    if (!name) continue;
+    // Extract name and version from the lockfile key (works for all pnpm lockfile versions)
+    const extracted = extractNameVersionFromKey(key);
+    if (!extracted) continue;
 
-    if (!pkg.version) continue;
+    const { name, version } = extracted;
 
-    const normalizedVersion = normalizeVersion(pkg.version);
+    // Integrity: v9 stores it under resolution.integrity; older formats under pkg.integrity
+    const integrity = pkg.resolution?.integrity ?? pkg.integrity;
 
     result.push({
       name,
-      version: normalizedVersion,
+      version,
       resolved: pkg.resolvedVersion,
-      integrity: pkg.integrity,
+      integrity,
       dependencies: pkg.dependencies || {},
       peerDependencies: pkg.peerDependencies,
       isDev: false,
       isPeer: false,
-      depth: calculateDepth(path),
+      depth: calculateDepth(key),
       license: undefined,
     });
   }
@@ -110,29 +145,15 @@ export function parseLockfilePackages(
 }
 
 /**
- * Extract package name from lockfile path
+ * Calculate dependency depth from lockfile key.
+ * Legacy formats encode nesting depth via repeated node_modules/ segments.
+ * v9 format lists all packages flat, so depth is always 0.
  */
-function extractPackageName(path: string): string | null {
-  const nodeModulesIndex = path.indexOf('node_modules/');
-  if (nodeModulesIndex === -1) return null;
-
-  const afterModules = path.slice(nodeModulesIndex + 'node_modules/'.length);
-  const segments = afterModules.split('/');
-
-  if (segments[0].startsWith('@')) {
-    return `${segments[0]}/${segments[1]}`;
-  }
-
-  return segments[0];
-}
-
-/**
- * Calculate dependency depth from path
- */
-function calculateDepth(path: string): number {
-  const matches = path.match(/node_modules/g);
-  if (!matches) return 0;
-  return Math.max(0, matches.length - 1);
+function calculateDepth(key: string): number {
+  const matches = key.match(/node_modules/g);
+  if (matches) return Math.max(0, matches.length - 1);
+  // v6/v9 format: all packages listed flat at depth 0 in the packages section
+  return 0;
 }
 
 /**

--- a/packages/sbom-generator/test/fixtures/pnpm-lock-v9.yaml
+++ b/packages/sbom-generator/test/fixtures/pnpm-lock-v9.yaml
@@ -1,0 +1,43 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+    devDependencies:
+      typescript:
+        specifier: ^5.0.0
+        version: 5.4.5
+
+packages:
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YH2rmg7I8DPqg==}
+    engines: {node: '>=12.0.0'}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-mock-react-integrity}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  typescript@5.4.5:
+    resolution: {integrity: sha512-mock-ts-integrity}
+    engines: {node: '>=14.17'}
+
+snapshots:
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  react@19.2.6: {}
+
+  typescript@5.4.5: {}

--- a/packages/sbom-generator/test/normalizers.test.ts
+++ b/packages/sbom-generator/test/normalizers.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for pnpm lockfile normalizer — specifically v9 format parsing
+ */
+import { describe, it, expect } from 'vitest';
+import { parseLockfilePackages } from '../src/normalizers/pnpm';
+
+describe('parseLockfilePackages', () => {
+  it('parses pnpm v9 format keys (no node_modules/ in key)', () => {
+    const packages = {
+      'js-yaml@4.1.1': {
+        resolution: { integrity: 'sha512-abc123' },
+      },
+      'react@19.2.6': {
+        resolution: { integrity: 'sha512-def456' },
+      },
+      '@scope/pkg@1.0.0': {
+        resolution: { integrity: 'sha512-ghi789' },
+      },
+    };
+
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+
+    expect(result).toHaveLength(3);
+    expect(result.find((d) => d.name === 'js-yaml')?.version).toBe('4.1.1');
+    expect(result.find((d) => d.name === 'react')?.version).toBe('19.2.6');
+    expect(result.find((d) => d.name === '@scope/pkg')?.version).toBe('1.0.0');
+  });
+
+  it('reads integrity from resolution.integrity for v9 packages', () => {
+    const packages = {
+      'js-yaml@4.1.1': {
+        resolution: { integrity: 'sha512-abc123' },
+      },
+    };
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+    expect(result[0].integrity).toBe('sha512-abc123');
+  });
+
+  it('strips peer context from v9 snapshot keys', () => {
+    const packages = {
+      'typescript@5.4.5(tslib@2.6.0)': {
+        resolution: { integrity: 'sha512-xyz' },
+      },
+    };
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('typescript');
+    expect(result[0].version).toBe('5.4.5');
+  });
+
+  it('strips leading slash from v5/v6 format keys', () => {
+    const packages = {
+      '/react@18.0.0': {
+        version: '18.0.0',
+        integrity: 'sha512-old',
+      },
+    };
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('react');
+    expect(result[0].version).toBe('18.0.0');
+  });
+
+  it('reads integrity from pkg.integrity for v5/v6 packages', () => {
+    const packages = {
+      '/react@18.0.0': {
+        version: '18.0.0',
+        integrity: 'sha512-legacy-hash',
+      },
+    };
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+    expect(result[0].integrity).toBe('sha512-legacy-hash');
+  });
+
+  it('prefers resolution.integrity over pkg.integrity when both present', () => {
+    const packages = {
+      'react@18.0.0': {
+        resolution: { integrity: 'sha512-from-resolution' },
+        integrity: 'sha512-old-field',
+      },
+    };
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+    expect(result[0].integrity).toBe('sha512-from-resolution');
+  });
+
+  it('handles scoped packages in v9 format', () => {
+    const packages = {
+      '@adobe/css-tools@4.4.4': {
+        resolution: { integrity: 'sha512-adobe-hash' },
+      },
+    };
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('@adobe/css-tools');
+    expect(result[0].version).toBe('4.4.4');
+  });
+
+  it('returns 0 deps for empty packages object', () => {
+    expect(parseLockfilePackages({}, '/fake/root')).toHaveLength(0);
+  });
+
+  it('skips malformed entries gracefully', () => {
+    const packages = {
+      'valid-pkg@1.0.0': { resolution: { integrity: 'sha512-ok' } },
+      'no-version-at-all': { resolution: { integrity: 'sha512-bad' } },
+      '': { resolution: { integrity: 'sha512-empty' } },
+    };
+    const result = parseLockfilePackages(packages as any, '/fake/root');
+    // Only valid-pkg@1.0.0 should parse successfully
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('valid-pkg');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two OSS issues logged from `stackwright-pro`.

---

### swp-cp3 — SBOM output directory mismatch + 0 deps (2 bugs)

**Bug 1 — Wrong output directory** (`packages/build-scripts`)
`sbom.writeTo(projectRoot)` was ignoring the `outputDir` set in `createSBOM()` and writing all SBOM files to the project root. Fixed by extracting `sbomOutputDir` to a variable and passing it to both calls.

**Bug 2 — 0 dependencies in every SBOM** (`packages/sbom-generator`)
`parseLockfilePackages()` had a guard `if (!path.includes('node_modules/')) continue` that skipped every entry in pnpm v9 lockfiles (this repo uses `lockfileVersion: '9.0'`; v9 keys look like `'react@19.2.6'` with no `node_modules/` segment). Also: v9 embeds version in the key (not a field), and integrity lives in `resolution.integrity`.

Fixes:
- New `extractNameVersionFromKey()` helper handles v5/v6 (`/pkg@ver`), v9 (`pkg@ver`), and v9 with peer context (`pkg@ver(peer@ver)`)
- Removed the broken `node_modules/` guard
- `calculateDepth()` returns 0 for v9 flat keys
- `analyzer.ts` now prefers `lockfile.snapshots` (v9 dep info) over `lockfile.packages`
- `LockfilePackage.version` is now optional (v9 embeds it in the key)

---

### swp-z21 — `stackwright.theme.yml` config file split (new feature)

Adds support for an optional `stackwright.theme.yml` sidecar that holds only the three theme-specific keys: `themeName`, `customTheme`, `fonts`. The prebuild merges these on top of `stackwright.yml` before validation.

**Problem it solves:** In multi-otter Pro sessions, Theme Otter and Page Otter both write to `stackwright.yml` and clobber each other's work. Now Theme Otter owns `stackwright.theme.yml`; Page Otter owns `stackwright.yml`. They never touch each other.

**Behavior:**
- Non-theme keys in `stackwright.theme.yml` are silently ignored
- Theme file values win over `stackwright.yml` for the three theme keys
- Both `.yml` and `.yaml` extensions supported
- Validation runs on the merged result — errors in either file surface at build time
- Documented in `AGENTS.md`

---

### Tests
- `@stackwright/sbom-generator`: +9 new tests for v9 lockfile parsing (52 total, all pass)
- `@stackwright/build-scripts`: +5 new tests for theme split (158 total, all pass)

### Packages changed
- `@stackwright/build-scripts` — minor (new feature) + patch (sbom dir fix)
- `@stackwright/sbom-generator` — patch (v9 parser fix)

Closes swp-cp3, swp-z21