### PR TITLE
docs(examples): showcase navigation section grouping in docs and SaaS examples

### DIFF
--- a/examples/saas-example/stackwright.yml
+++ b/examples/saas-example/stackwright.yml
@@ -17,14 +17,18 @@ appBar:
 navigation:
   - label: "Home"
     href: "/"
-  - label: "Features"
-    href: "/features"
-  - label: "Pricing"
-    href: "/pricing"
-  - label: "About"
-    href: "/about"
-  - label: "Contact"
-    href: "/contact"
+  - section: "Product"
+    items:
+      - label: "Features"
+        href: "/features"
+      - label: "Pricing"
+        href: "/pricing"
+  - section: "Company"
+    items:
+      - label: "About"
+        href: "/about"
+      - label: "Contact"
+        href: "/contact"
 
 footer:
   backgroundColor: "primary"

--- a/examples/stackwright-docs/stackwright.yml
+++ b/examples/stackwright-docs/stackwright.yml
@@ -31,24 +31,28 @@ search:
 # Sidebar navigation (persistent left sidebar)
 sidebar:
   navigation:
-    - label: "📖 Documentation"
-      href: "/getting-started"
-    - label: "🚀 Getting Started"
-      href: "/getting-started"
-    - label: "📦 Content Types"
-      href: "/content-types"
-    - label: "🧪 Showcase"
-      href: "/showcase"
-    - label: "🏗️ Architecture"
-      href: "/architecture"
-    - label: "⌨️ CLI Reference"
-      href: "/cli"
-    - label: "🤖 Otter Raft"
-      href: "/otter-raft"
-    - label: "🔐 Pro"
-      href: "/pro"
-    - label: "🙏 Acknowledgements"
-      href: "/acknowledgements"
+    - section: "Learn"
+      items:
+        - label: "\U0001F680 Getting Started"
+          href: "/getting-started"
+        - label: "\U0001F4E6 Content Types"
+          href: "/content-types"
+        - label: "\U0001F9EA Showcase"
+          href: "/showcase"
+    - section: "Reference"
+      items:
+        - label: "\U0001F3D7\uFE0F Architecture"
+          href: "/architecture"
+        - label: "\u2328\uFE0F CLI Reference"
+          href: "/cli"
+        - label: "\U0001F916 Otter Raft"
+          href: "/otter-raft"
+    - section: "More"
+      items:
+        - label: "\U0001F510 Pro"
+          href: "/pro"
+        - label: "\U0001F64F Acknowledgements"
+          href: "/acknowledgements"
 
   collapsed: false
   width: 260
@@ -62,10 +66,12 @@ footer:
       href: "https://github.com/Per-Aspera-LLC/stackwright"
     - label: "Source for this Site"
       href: "https://github.com/Per-Aspera-LLC/stackwright/tree/main/examples/stackwright-docs"
-    - label: "Terms"
-      href: "/terms-and-conditions"
-    - label: "Privacy Policy"
-      href: "/privacy-policy"
+    - section: "Legal"
+      items:
+        - label: "Terms"
+          href: "/terms-and-conditions"
+        - label: "Privacy Policy"
+          href: "/privacy-policy"
 
 customTheme:
   id: "stackwright-docs"


### PR DESCRIPTION
## Summary

Updates two example apps to demonstrate the `NavigationSection` grouping feature shipped in PR #496.

### Changes

**`examples/stackwright-docs/stackwright.yml`**
- **Sidebar**: Restructured 9 flat navigation items into 3 sections:
  - **Learn**: Getting Started, Content Types, Showcase
  - **Reference**: Architecture, CLI Reference, Otter Raft
  - **More**: Pro, Acknowledgements
- **Footer**: Grouped "Terms" and "Privacy Policy" under a "Legal" section header
- Removed redundant " Documentation" link (duplicate of Getting Started)

**`examples/saas-example/stackwright.yml`**
- **Top nav**: Restructured 5 flat links into:
  - "Home" (standalone link)
  - **Product** section: Features, Pricing
  - **Company** section: About, Contact

### Rendering Coverage

| Component | Example | Demonstrates |
|---|---|---|
| NavSidebar (`SectionHeader`) | stackwright-docs sidebar | Section headers as visual group headings |
| TopAppBar (`NavDropdown`) | saas-example nav | Sections as desktop dropdown menus |
| BottomAppBar (column headers) | stackwright-docs footer | Section as footer column header |

### Verification
-  `pnpm build` — all packages, schema validation passed
-  `pnpm test` — 954 tests, all green
