### PR TITLE
feat(mcp): expose register*Tools via /register subpath (fixes swp-hbdx)

### DIFF
--- a/.changeset/mcp-register-subpath.md
+++ b/.changeset/mcp-register-subpath.md
@@ -1,0 +1,20 @@
+---
+"@stackwright/mcp": minor
+---
+
+feat(mcp): expose register\*Tools and closeBrowser via /register subpath for downstream composition (fixes swp-hbdx)
+
+Adds a new `@stackwright/mcp/register` subpath export that re-exports all
+tool registrar functions and `closeBrowser` without any side effects (no
+McpServer instantiation, no transport binding). Downstream packages (Pro,
+third-party MCP composers) can now import and compose OSS tools onto their
+own McpServer instances.
+
+Changes:
+- New `src/register.ts` — pure re-export module, no side effects
+- `src/server.ts` — refactored to import from `register.ts` (single source of truth)
+- `package.json` — `./register` added to exports map
+- `tsup.config.ts` — `register` entry added; DTS enabled for `register` only
+- `tsconfig.json` — `types: ["node"]` added (required for DTS generation)
+- `vitest.config.ts` — alias for `@stackwright/build-scripts` (Vite 7 CJS resolution workaround)
+- `test/register-subpath.test.ts` — integration test asserting full tool surface on a real McpServer

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -16,6 +16,10 @@
         ".": {
             "types": "./dist/server.d.ts",
             "require": "./dist/server.js"
+        },
+        "./register": {
+            "types": "./dist/register.d.ts",
+            "require": "./dist/register.js"
         }
     },
     "files": [

--- a/packages/mcp/src/register.ts
+++ b/packages/mcp/src/register.ts
@@ -1,0 +1,17 @@
+/**
+ * Public API for composing Stackwright MCP tools onto a downstream MCP server.
+ * All registrars take an McpServer instance and register their tools onto it.
+ * No side effects — safe to import without spinning up a transport or process.
+ */
+
+export { registerContentTypeTools } from './tools/content-types.js';
+export { registerPageTools } from './tools/pages.js';
+export { registerSiteTools } from './tools/site.js';
+export { registerProjectTools } from './tools/project.js';
+export { registerGitOpsTools } from './tools/git-ops.js';
+export { registerBoardTools } from './tools/board.js';
+export { registerCollectionTools } from './tools/collections.js';
+export { registerIntegrationTools } from './tools/integrations.js';
+export { registerComposeTools } from './tools/compose.js';
+export { registerRenderTools, closeBrowser } from './tools/render.js';
+export { registerA11yTools } from './tools/a11y.js';

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,16 +1,19 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { registerContentTypeTools } from './tools/content-types.js';
-import { registerPageTools } from './tools/pages.js';
-import { registerSiteTools } from './tools/site.js';
-import { registerProjectTools } from './tools/project.js';
-import { registerGitOpsTools } from './tools/git-ops.js';
-import { registerBoardTools } from './tools/board.js';
-import { registerCollectionTools } from './tools/collections.js';
-import { registerIntegrationTools } from './tools/integrations.js';
-import { registerComposeTools } from './tools/compose.js';
-import { registerRenderTools, closeBrowser } from './tools/render.js';
-import { registerA11yTools } from './tools/a11y.js';
+import {
+  registerContentTypeTools,
+  registerPageTools,
+  registerSiteTools,
+  registerProjectTools,
+  registerGitOpsTools,
+  registerBoardTools,
+  registerCollectionTools,
+  registerIntegrationTools,
+  registerComposeTools,
+  registerRenderTools,
+  registerA11yTools,
+  closeBrowser,
+} from './register.js';
 import { version } from '../package.json';
 
 const server = new McpServer({

--- a/packages/mcp/test/__mocks__/build-scripts.ts
+++ b/packages/mcp/test/__mocks__/build-scripts.ts
@@ -1,0 +1,17 @@
+/**
+ * Stub for @stackwright/build-scripts used in vitest.
+ *
+ * The real package only publishes a CJS `require` condition in its exports
+ * map. Vite 7+ will not fall back to `main` when an `exports` map is present
+ * and no matching condition is found, causing a hard module-resolution failure
+ * during Vite's static import-analysis phase — before any vi.mock() hoisting
+ * can intercept it.
+ *
+ * This stub is aliased in via vitest.config.ts so Vite resolves a real file
+ * with a proper ESM `import` path instead.
+ *
+ * Kept minimal — only exports the symbol that render.ts actually uses.
+ */
+export const runPrebuild = async (): Promise<void> => {
+  /* no-op stub */
+};

--- a/packages/mcp/test/register-subpath.test.ts
+++ b/packages/mcp/test/register-subpath.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration test for the /register subpath public API (swp-hbdx).
+ *
+ * Instantiates a real McpServer (no mocking), calls every registrar imported
+ * from src/register.ts, then introspects the server's internal tool registry
+ * to assert the full expected tool surface is present.
+ *
+ * If anyone adds a new tool to an OSS tools file and forgets to update
+ * register.ts, this test fails immediately. That's the whole point.
+ */
+
+/**
+ * Two mocks are required before imports:
+ *
+ * 1. `playwright` — render.ts → page-renderer.ts → playwright. No Chromium
+ *    in a fast registration test.
+ * 2. `@stackwright/build-scripts` — render.ts imports `runPrebuild` from it.
+ *    That package only publishes a CJS `require` condition; Vite's default
+ *    resolver looks for `import` and fails at module-graph time (not at call
+ *    time). Mocking it here prevents the resolution failure. We are testing
+ *    tool *registration*, not prebuild execution.
+ */
+import { vi, describe, it, expect, beforeAll } from 'vitest';
+
+vi.mock('playwright', () => ({
+  chromium: { launch: vi.fn() },
+}));
+
+vi.mock('@stackwright/build-scripts', () => ({
+  runPrebuild: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  registerContentTypeTools,
+  registerPageTools,
+  registerSiteTools,
+  registerProjectTools,
+  registerGitOpsTools,
+  registerBoardTools,
+  registerCollectionTools,
+  registerIntegrationTools,
+  registerComposeTools,
+  registerRenderTools,
+  registerA11yTools,
+  closeBrowser,
+} from '../src/register';
+
+// ---------------------------------------------------------------------------
+// All tool names that must be present on the composed server.
+// Sourced by reading every tools/*.ts file — update here when adding new tools.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_TOOLS = [
+  // content-types.ts
+  'stackwright_get_content_types',
+  'stackwright_preview_component',
+  // pages.ts
+  'stackwright_list_pages',
+  'stackwright_get_page',
+  'stackwright_write_page',
+  'stackwright_add_page',
+  'stackwright_validate_pages',
+  // site.ts
+  'stackwright_get_site_config',
+  'stackwright_write_site_config',
+  'stackwright_list_themes',
+  'stackwright_validate_site',
+  // project.ts
+  'stackwright_get_project_info',
+  'stackwright_scaffold_project',
+  // git-ops.ts
+  'stackwright_stage_changes',
+  'stackwright_open_pr',
+  // board.ts
+  'stackwright_get_board',
+  // collections.ts
+  'stackwright_list_collections',
+  'stackwright_create_collection',
+  // integrations.ts
+  'stackwright_list_integrations',
+  'stackwright_get_integration',
+  'stackwright_add_integration',
+  // compose.ts
+  'stackwright_compose_site',
+  // render.ts
+  'stackwright_check_dev_server',
+  'stackwright_render_page',
+  'stackwright_render_diff',
+  'stackwright_render_yaml',
+  // a11y.ts
+  'stackwright_test_a11y',
+] as const;
+
+// ---------------------------------------------------------------------------
+
+describe('register subpath — tool surface integration', () => {
+  let server: McpServer;
+  let registeredToolNames: string[];
+
+  beforeAll(() => {
+    server = new McpServer({ name: 'test-stackwright', version: '0.0.0-test' });
+
+    // Register all OSS tools — same order as server.ts
+    registerContentTypeTools(server);
+    registerPageTools(server);
+    registerSiteTools(server);
+    registerProjectTools(server);
+    registerGitOpsTools(server);
+    registerBoardTools(server);
+    registerCollectionTools(server);
+    registerIntegrationTools(server);
+    registerComposeTools(server);
+    registerRenderTools(server);
+    registerA11yTools(server);
+
+    // Introspect via the internal registry (plain object, keys = tool names).
+     
+    registeredToolNames = Object.keys((server as any)._registeredTools);
+  });
+
+  it('registers every expected tool', () => {
+    for (const toolName of EXPECTED_TOOLS) {
+      expect(registeredToolNames, `missing tool: ${toolName}`).toContain(toolName);
+    }
+  });
+
+  it('registers no unexpected tools (catches forgotten register.ts entries)', () => {
+    // If a tool appears in the server but not in EXPECTED_TOOLS, this test
+    // forces the author to add it to EXPECTED_TOOLS — keeping the list honest.
+    const unexpected = registeredToolNames.filter(
+      (name) => !(EXPECTED_TOOLS as readonly string[]).includes(name)
+    );
+    expect(
+      unexpected,
+      `unexpected tools found (add them to EXPECTED_TOOLS): ${unexpected.join(', ')}`
+    ).toHaveLength(0);
+  });
+
+  it('exports closeBrowser as a callable function', () => {
+    expect(typeof closeBrowser).toBe('function');
+  });
+
+  it('total tool count matches expected list', () => {
+    expect(registeredToolNames).toHaveLength(EXPECTED_TOOLS.length);
+  });
+});

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "bundler",
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "6.0",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -5,9 +5,12 @@ import path from 'path';
 export default defineConfig({
   entry: {
     server: 'src/server.ts',
+    register: 'src/register.ts',
   },
   format: ['cjs'],
-  dts: false,
+  // Only emit .d.ts for register.ts — server.ts is a binary entrypoint and
+  // its Node globals (process, console) upset the DTS type-checker under lib:[es2020].
+  dts: { entry: { register: 'src/register.ts' } },
   splitting: false,
   sourcemap: false,
   clean: true,

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,6 +1,18 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // @stackwright/build-scripts only publishes a CJS `require` condition.
+      // Vite 7 refuses to resolve packages that have an `exports` map with no
+      // matching condition — it won't fall back to `main`. This alias points
+      // to a local stub so the test runner can load render.ts at all.
+      // The stub only matters for tests that import render-related modules;
+      // the real package is used at runtime via the built CJS bundle.
+      '@stackwright/build-scripts': path.resolve(__dirname, 'test/__mocks__/build-scripts.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
- Add src/register.ts: pure re-export module, no side effects
- Refactor src/server.ts to import from register.ts (single source of truth)
- Add ./register to exports map in package.json
- Add register entry to tsup config; enable DTS for register only
- Add types:[node] to tsconfig (required for DTS generation)
- Add @stackwright/build-scripts alias in vitest config (Vite 7 CJS workaround)
- Add integration test asserting full tool surface on a real McpServer