### PR TITLE
fix(mcp): reset launchPromise on rejection in getBrowser() [swp-nqqp]

### DIFF
--- a/.changeset/swp-nqqp-mcp-getbrowser-catch-reset.md
+++ b/.changeset/swp-nqqp-mcp-getbrowser-catch-reset.md
@@ -1,0 +1,11 @@
+---
+"@stackwright/mcp": patch
+---
+
+Fix `getBrowser()` in the MCP server caching a rejected `chromium.launch()` promise forever.
+
+Previously, if the first browser launch rejected (e.g. before `npx playwright install` had completed the chromium binary download), the rejected promise was stored in the module-level `launchPromise` cache and never reset, causing every subsequent `stackwright_render_page` / `stackwright_test_a11y` call for the lifetime of the MCP session to return the frozen rejection. The only recovery was restarting the host process.
+
+Added a `.catch` reset that clears `launchPromise` on rejection and re-throws, so the next call retries fresh.
+
+Same "fail-loudly at the seam" family as the four P0 launcher bugs (swp-eezo/85mm/ohvg/j2cq). Discovered during post-dhl-opus-012 arc validation when a fresh QA re-run against the disaster-health-logistics artifact hit the cached rejection and could not recover without a Claude Code restart.

--- a/packages/mcp/src/renderer/page-renderer.ts
+++ b/packages/mcp/src/renderer/page-renderer.ts
@@ -64,6 +64,12 @@ async function getBrowser(): Promise<Browser> {
         browserInstance = browser;
         launchPromise = null;
         return browser;
+      })
+      .catch((err) => {
+        // Reset so the next getBrowser() call retries fresh instead of
+        // returning this frozen rejection for the rest of the MCP session.
+        launchPromise = null;
+        throw err;
       });
   }
 

--- a/packages/mcp/test/render-tools.test.ts
+++ b/packages/mcp/test/render-tools.test.ts
@@ -39,6 +39,46 @@ describe('closeBrowser', () => {
   });
 });
 
+describe('getBrowser() rejection recovery (swp-nqqp)', () => {
+  it('retries after a rejected launch rather than caching the rejection', async () => {
+    const { chromium } = await import('playwright');
+
+    const launchError = new Error('Chromium binary not found — run npx playwright install');
+    const screenshotBuffer = Buffer.from('fake-png');
+    const mockPage = {
+      setViewportSize: vi.fn(),
+      goto: vi.fn().mockResolvedValue({ status: () => 200 }),
+      close: vi.fn().mockResolvedValue(undefined),
+      waitForTimeout: vi.fn(),
+      screenshot: vi.fn().mockResolvedValue(screenshotBuffer),
+    };
+    const mockBrowser = {
+      isConnected: vi.fn().mockReturnValue(false),
+      newPage: vi.fn().mockResolvedValue(mockPage),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // First launch rejects, second resolves
+    vi.mocked(chromium.launch)
+      .mockRejectedValueOnce(launchError)
+      .mockResolvedValueOnce(mockBrowser as any);
+
+    // Start clean
+    await closeBrowser();
+
+    const { renderPage } = await import('../src/renderer/page-renderer');
+
+    // First call must reject with the original error
+    await expect(renderPage({ baseUrl: 'http://localhost:3000', slug: '/' })).rejects.toThrow(
+      'Chromium binary not found'
+    );
+
+    // Second call must retry fresh — without the fix this returns the cached rejection
+    const result = await renderPage({ baseUrl: 'http://localhost:3000', slug: '/' });
+    expect(result.image).toBe(screenshotBuffer.toString('base64'));
+  });
+});
+
 describe('renderPage', () => {
   it('throws when server returns error status', async () => {
     const { chromium } = await import('playwright');


### PR DESCRIPTION
## Summary

Fixes swp-nqqp. Adds the missing `.catch` reset in `@stackwright/mcp`'s `getBrowser()` so a rejected `chromium.launch()` no longer caches for the lifetime of the MCP session.

## The bug

Module-level `launchPromise` was set to `null` on `.then` success but had no matching reset on rejection. First failed launch → permanent stuck state for the session. Only recovery: restart Claude Code / host process.

Discovered during post-dhl-opus-012 arc validation. A fresh QA re-run against `test-runs/disaster-health-logistics` couldn't render any routes because the MCP browser was permanently jammed — Playwright itself worked fine when called directly from `node`.

## The fix

Add `.catch(err => { launchPromise = null; throw err })` to the launch chain. On rejection, cache is cleared and the error re-throws so the caller sees it AND the next `getBrowser()` call retries fresh.

## Test

New unit test: `getBrowser() retries after a rejected launch rather than caching the rejection`. Mocks `chromium.launch` to reject-then-resolve, asserts the second call succeeds.

**Test count: 62 → 63** (`@stackwright/mcp`, all green)

## Note on package location

The step-by-step instructions predicted the bug was in `@stackwright-pro/mcp` but it lives in `@stackwright/mcp` (OSS) — which matches the bead title exactly. The Pro MCP server imports `registerRenderTools` / `registerA11yTools` / `closeBrowser` from `@stackwright/mcp/register`, so the fix here heals the Pro QA otter too.

## Family

Same "fail-loudly at the seam" family as swp-eezo / swp-85mm / swp-ohvg / swp-j2cq (the four P0 launcher bugs from 2026-06-23) and the sibling beads swp-ckyn / swp-7bfa / swp-0fcq filed in the same validation session.

## Changeset

Patch bump on `@stackwright/mcp`. Pre-release mode active → alpha channel on publish.