### PR TITLE
feat(build-scripts): prebuild plugin auto-discovery

### DIFF
--- a/.changeset/prebuild-plugin-discovery.md
+++ b/.changeset/prebuild-plugin-discovery.md
@@ -1,0 +1,40 @@
+---
+"@stackwright/build-scripts": minor
+"@stackwright/types": minor
+---
+
+Add three-tier plugin auto-discovery to `stackwright-prebuild` so Pro content types (`data_table_pulse`, `metric_card_pulse`, etc.) validate correctly during prebuild — matching the fidelity of `next dev` runtime.
+
+**Root cause fixed:** the CLI binary previously invoked `runPrebuild()` with an empty `plugins` array, so `validatePageContent()` saw no schemas for Pro types and emitted `[WARN] Unknown content type data_table_pulse` even when `@stackwright-pro/build-scripts-plugins` was correctly installed. Prebuild is a distinct runtime from the Next.js app process — `registerContentType()` calls in app code never reached it. This PR adds the missing build-time discovery layer.
+
+## Discovery tiers
+
+1. **Convention** — attempts `require('@stackwright-pro/build-scripts-plugins')` from the project's `node_modules`. Silent soft-fail if absent (normal OSS case).
+2. **Config** — reads `prebuild.plugins: string[]` from `stackwright.yml`. Hard-fails with a clear error naming any missing package (typo guard).
+3. **Explicit override** — `runPrebuild({ plugins })` bypasses discovery entirely. Preserves existing programmatic wrappers and test injection.
+
+## CLI flags
+
+- `--no-plugin-discovery` — disable all auto-discovery
+- `--plugins pkg-a,pkg-b` — comma-separated override list, skips Tier A/B
+
+## Type changes (`@stackwright/types`)
+
+- `PrebuildOptions` gains optional `pluginDiscovery?: boolean` and `pluginOverride?: string[]`
+- `siteConfigSchema` gains optional `prebuild: { plugins?: string[]; unknownContentTypes?: 'error' | 'warn' | 'ignore' }` block (behavior wiring for `unknownContentTypes` is a follow-up)
+
+## Backward compatibility
+
+- `runPrebuild({ plugins: [...] })` → unchanged (explicit array wins over discovery)
+- `runPrebuild({ plugins: [] })` → unchanged (empty array = "explicitly no plugins")
+- `runPrebuild()` with no `plugins` field → **new behavior**: discovery runs
+
+## Implementation notes
+
+- Discovery is **synchronous** (uses CJS `require()` via `createRequire`, not `await import()`) to preserve the `runWatch()` invariant that all sync file writes happen before the first `await` in `runPrebuild`. All Pro plugins are CJS per the project rule "no `type: module` in packages/*", so this covers all production cases.
+- The canonical Pro bundle name (`@stackwright-pro/build-scripts-plugins`) is an intentional soft-coupling from OSS to Pro — resolved dynamically, never imported.
+- CLI logging follows existing convention: `[INFO]` fires only when the user deviates from the default (mirrors `--no-sbom` etc.).
+
+## Testing
+
+12 integration tests with real fixtures under `packages/build-scripts/test/fixtures/discovery/` — real temp dirs, real fake CJS plugin packages with real Zod schemas. No mocks. Full suite 278/278 green. Manual empty-folder smoke test confirmed silent Tier A soft-fail on vanilla OSS projects.

--- a/packages/build-scripts/src/compile/context.ts
+++ b/packages/build-scripts/src/compile/context.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import type { PrebuildOptions, PrebuildPlugin, PrebuildPluginContext } from '@stackwright/types';
+import { discoverPlugins } from './discover';
 
 /**
  * Internal context threaded through all compile primitives.
@@ -31,13 +32,10 @@ export interface CompileContext {
  * Build a CompileContext from PrebuildOptions.
  * Resolves all path derivations in one place.
  */
-export function createCompileContext(
-  options?: string | PrebuildOptions
-): CompileContext {
+export function createCompileContext(options?: string | PrebuildOptions): CompileContext {
   const projectRoot =
     typeof options === 'string' ? options : (options?.projectRoot ?? process.cwd());
-  const plugins =
-    typeof options === 'object' && options !== null ? (options.plugins ?? []) : [];
+  const plugins = typeof options === 'object' && options !== null ? (options.plugins ?? []) : [];
   const unknownContentTypes =
     typeof options === 'object' && options !== null
       ? (options.unknownContentTypes ?? 'error')
@@ -59,6 +57,38 @@ export function createCompileContext(
     unknownContentTypes,
     imageOptimizationEnabled,
   };
+}
+
+/**
+ * Discover plugins and attach them to an existing CompileContext in-place.
+ *
+ * Called by runPrebuild() immediately after createCompileContext() and before
+ * compileAll(). Skipped entirely when options.plugins is explicitly set
+ * (including an explicit empty array — [] means "I want no plugins").
+ *
+ * Intentionally synchronous — discoverPlugins() uses CJS require() to avoid
+ * introducing an async yield before the synchronous file-write phase of
+ * compileAll(). runWatch() calls runPrebuild() without await, relying on
+ * the invariant that all sync writes precede the first await in runPrebuild.
+ */
+export function discoverAndAttachPlugins(
+  ctx: CompileContext,
+  options?: string | PrebuildOptions
+): void {
+  // Explicit plugins array (including []) → caller owns the list, skip discovery.
+  if (typeof options === 'object' && options !== null && 'plugins' in options) {
+    return;
+  }
+
+  const opts = typeof options === 'object' && options !== null ? options : {};
+
+  const discovered = discoverPlugins(ctx.projectRoot, {
+    enabled: opts.pluginDiscovery,
+    overrideList: opts.pluginOverride,
+  });
+
+  // Mutate in place — ctx is the single instance threaded through compileAll.
+  ctx.plugins = discovered;
 }
 
 /**

--- a/packages/build-scripts/src/compile/discover.ts
+++ b/packages/build-scripts/src/compile/discover.ts
@@ -1,0 +1,259 @@
+/**
+ * Plugin auto-discovery for the stackwright-prebuild CLI.
+ *
+ * Resolves plugins in tier order using synchronous CJS require():
+ *   Tier A — Convention: @stackwright-pro/build-scripts-plugins (soft-fail if absent)
+ *   Tier B — Config: `prebuild.plugins` in stackwright.yml (hard-fail on typos)
+ *
+ * Tier C (explicit `plugins` array in PrebuildOptions) is handled by the
+ * caller — if `plugins` is set, discovery is skipped entirely.
+ *
+ * ### Why synchronous require() instead of dynamic import()?
+ *
+ * `runWatch()` calls `runPrebuild()` without `await`, relying on the
+ * invariant that all synchronous file writes happen BEFORE the first
+ * `await` inside `runPrebuild`. Using `await import()` for discovery would
+ * break that invariant. Since all current plugin packages are CJS (built with
+ * tsup, never add `"type": "module"` per project rules), synchronous require()
+ * covers all production cases. ESM-only plugins can be added as a follow-up.
+ *
+ * ### Resolution anchor
+ *
+ * `createRequire` is anchored to `projectRoot/noop.js`, so resolution
+ * uses the PROJECT's node_modules, not build-scripts' own — correct in
+ * both local development and monorepo setups.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { createRequire } from 'module';
+import { pathToFileURL } from 'url';
+import yaml from 'js-yaml';
+import type { PrebuildPlugin } from '@stackwright/types';
+
+// ---------------------------------------------------------------------------
+// Well-known names (exported for tests + AGENTS.md docs)
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical Pro plugin bundle package name.
+ * Intentional soft-coupling: the OSS package never has a hard dep on this —
+ * it's resolved dynamically from the project's node_modules at runtime.
+ */
+export const CANONICAL_PRO_BUNDLE = '@stackwright-pro/build-scripts-plugins';
+
+// ---------------------------------------------------------------------------
+// Discovery options
+// ---------------------------------------------------------------------------
+
+export interface DiscoverPluginsOptions {
+  /**
+   * When `false`, skip all discovery and return [].
+   * Mirrors the `--no-plugin-discovery` CLI flag.
+   */
+  enabled?: boolean;
+
+  /**
+   * When provided, skip Tier A + Tier B entirely and load only these
+   * package names (Tier B resolution logic, hard-fail on missing packages).
+   * Mirrors the `--plugins pkg-a,pkg-b` CLI flag.
+   */
+  overrideList?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a require() resolver anchored to `projectRoot/noop.js`.
+ * This makes module resolution use the project's node_modules, not ours.
+ */
+function makeProjectRequire(projectRoot: string): NodeRequire {
+  return createRequire(pathToFileURL(path.join(projectRoot, 'noop.js')).href);
+}
+
+/**
+ * Extract a plugin array from a CJS `module.exports` value.
+ *
+ * Accepts (in priority order):
+ *   - `exports.proPlugins`  (array)  — Pro bundle convention
+ *   - `exports.plugins`     (array)  — generic naming
+ *   - `exports`             (array)  — module.exports IS the array
+ *   - `exports.plugin`      (object) — single plugin, wrapped in array
+ *   - `exports`             (object with .name) — single plugin as default export
+ *
+ * Returns null and warns if nothing recognizable was found.
+ */
+function extractPluginsFromCJS(
+  mod: Record<string, any>,
+  packageName: string
+): PrebuildPlugin[] | null {
+  const candidates = [
+    mod.proPlugins,
+    mod.plugins,
+    Array.isArray(mod) ? mod : null, // module.exports = [plugin1, plugin2]
+    mod.plugin,
+    mod.default?.proPlugins, // unusual but defensive
+    mod.default?.plugins,
+    typeof mod.name === 'string' ? mod : null, // module.exports = { name: '...', ... }
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (Array.isArray(candidate)) return candidate as PrebuildPlugin[];
+    if (typeof candidate === 'object' && typeof candidate.name === 'string') {
+      return [candidate as PrebuildPlugin];
+    }
+  }
+
+  console.warn(
+    `  [WARN] Plugin package "${packageName}" was resolved but no recognized export found.\n` +
+      `         Expected: proPlugins, plugins, plugin, or the default export (array or plugin object).`
+  );
+  return null;
+}
+
+/**
+ * Synchronously load a plugin package from the project's node_modules.
+ *
+ * @param packageName   - e.g. '@stackwright-pro/build-scripts-plugins'
+ * @param projectRequire - createRequire'd to the project root
+ * @param hardFail      - if true, throw on resolution failure (config tier behavior)
+ */
+function loadPackageSync(
+  packageName: string,
+  projectRequire: NodeRequire,
+  hardFail: boolean
+): PrebuildPlugin[] | null {
+  let mod: unknown;
+  try {
+    mod = projectRequire(packageName);
+  } catch {
+    if (hardFail) {
+      throw new Error(
+        `[prebuild] Plugin package "${packageName}" could not be resolved from the project's node_modules.\n` +
+          `  Make sure it is listed in your project's dependencies and installed.`
+      );
+    }
+    return null; // Soft fail — normal OSS case when Pro bundle is absent
+  }
+
+  if (!mod || typeof mod !== 'object') {
+    console.warn(`  [WARN] Plugin package "${packageName}" exported a non-object value.`);
+    return null;
+  }
+
+  return extractPluginsFromCJS(mod as Record<string, any>, packageName);
+}
+
+/**
+ * Read `prebuild.plugins` from stackwright.yml (Tier B config).
+ * Returns [] if the file or the section is absent (silent skip).
+ */
+function readConfigPluginNames(projectRoot: string): string[] {
+  const candidates = ['stackwright.yml', 'stackwright.yaml'];
+  for (const filename of candidates) {
+    const filePath = path.join(projectRoot, filename);
+    if (!fs.existsSync(filePath)) continue;
+
+    let raw: unknown;
+    try {
+      raw = yaml.load(fs.readFileSync(filePath, 'utf8'));
+    } catch {
+      return [];
+    }
+
+    if (!raw || typeof raw !== 'object') return [];
+    const config = raw as Record<string, unknown>;
+    const prebuild = config.prebuild as Record<string, unknown> | undefined;
+    if (!prebuild || !Array.isArray(prebuild.plugins)) return [];
+    return (prebuild.plugins as unknown[]).filter((p) => typeof p === 'string') as string[];
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// De-duplication
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge plugin arrays, keeping the first occurrence when plugin.name collides.
+ */
+function deduplicatePlugins(plugins: PrebuildPlugin[]): PrebuildPlugin[] {
+  const seen = new Set<string>();
+  const result: PrebuildPlugin[] = [];
+  for (const plugin of plugins) {
+    if (seen.has(plugin.name)) {
+      console.log(`  [DEBUG] Skipping duplicate plugin: ${plugin.name}`);
+      continue;
+    }
+    seen.add(plugin.name);
+    result.push(plugin);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover prebuild plugins for the given project root.
+ *
+ * Fully synchronous — uses CJS require() so it doesn't introduce an async
+ * yield point before the synchronous file-write phase of runPrebuild.
+ *
+ * Resolution order:
+ *   1. If `options.enabled === false` → return [] immediately.
+ *   2. If `options.overrideList` is provided → load exactly those packages
+ *      (hard-fail on any missing), skip Tier A/B.
+ *   3. Tier A: try to load CANONICAL_PRO_BUNDLE from project node_modules (soft-fail).
+ *   4. Tier B: read `prebuild.plugins` from stackwright.yml, load each (hard-fail on missing).
+ *   5. De-duplicate by plugin.name (first wins).
+ *
+ * @param projectRoot - Absolute path to the project (where stackwright.yml lives).
+ * @param options     - Discovery behavior overrides.
+ */
+export function discoverPlugins(
+  projectRoot: string,
+  options: DiscoverPluginsOptions = {}
+): PrebuildPlugin[] {
+  if (options.enabled === false) {
+    return [];
+  }
+
+  const projectRequire = makeProjectRequire(projectRoot);
+  const discovered: PrebuildPlugin[] = [];
+
+  // --- Override list (mirrors --plugins CLI flag) --------------------------
+  if (options.overrideList && options.overrideList.length > 0) {
+    for (const packageName of options.overrideList) {
+      const loaded = loadPackageSync(packageName, projectRequire, /* hardFail */ true);
+      if (loaded) {
+        console.log(`  [OK] Discovered plugin: ${packageName} (override)`);
+        discovered.push(...loaded);
+      }
+    }
+    return deduplicatePlugins(discovered);
+  }
+
+  // --- Tier A: Convention --------------------------------------------------
+  const tierAPlugins = loadPackageSync(CANONICAL_PRO_BUNDLE, projectRequire, /* hardFail */ false);
+  if (tierAPlugins) {
+    console.log(`  [OK] Discovered plugins: ${CANONICAL_PRO_BUNDLE} (convention)`);
+    discovered.push(...tierAPlugins);
+  }
+
+  // --- Tier B: Config -------------------------------------------------------
+  const configPluginNames = readConfigPluginNames(projectRoot);
+  for (const packageName of configPluginNames) {
+    const loaded = loadPackageSync(packageName, projectRequire, /* hardFail */ true);
+    if (loaded) {
+      console.log(`  [OK] Discovered plugin: ${packageName} (config)`);
+      discovered.push(...loaded);
+    }
+  }
+
+  return deduplicatePlugins(discovered);
+}

--- a/packages/build-scripts/src/compile/index.ts
+++ b/packages/build-scripts/src/compile/index.ts
@@ -46,8 +46,11 @@ export {
 } from './fonts';
 export type { FontLink } from './fonts';
 
-export { createCompileContext, toPluginContext } from './context';
+export { createCompileContext, toPluginContext, discoverAndAttachPlugins } from './context';
 export type { CompileContext } from './context';
+
+export { discoverPlugins, CANONICAL_PRO_BUNDLE } from './discover';
+export type { DiscoverPluginsOptions } from './discover';
 
 // ---------------------------------------------------------------------------
 // compileAll

--- a/packages/build-scripts/src/prebuild.ts
+++ b/packages/build-scripts/src/prebuild.ts
@@ -23,6 +23,7 @@ import fs from 'fs';
 import path from 'path';
 import type { PrebuildOptions } from '@stackwright/types';
 import { createCompileContext, compileAll } from './compile';
+import { discoverAndAttachPlugins } from './compile/context';
 import { generateSitemap, generateRobotsTxt, collectPageMeta } from './seo';
 
 // ---------------------------------------------------------------------------
@@ -89,6 +90,11 @@ export async function runPrebuild(options?: string | PrebuildOptions): Promise<v
   console.log('Stackwright prebuild starting...');
 
   const ctx = createCompileContext(options);
+
+  // Auto-discover plugins from project node_modules (skipped when options.plugins is set).
+  // Synchronous — must run before compileAll so plugins are wired before page validation.
+  discoverAndAttachPlugins(ctx, options);
+
   // compileAll runs sync file-writes immediately (before any await),
   // then awaits async operations (fonts, image optimization, plugin hooks).
   // This preserves the original behavior where _site.json, _root.json, etc.
@@ -171,12 +177,26 @@ if (require.main === module) {
   const noSBOM = process.argv.includes('--no-sbom');
   const sbomStrict = process.argv.includes('--sbom-strict');
   const noImageOptimization = process.argv.includes('--no-image-optimization');
+  const noPluginDiscovery = process.argv.includes('--no-plugin-discovery');
+
+  // --plugins pkg-a,pkg-b  (comma-separated override list)
+  const pluginsArgIdx = process.argv.findIndex((a) => a === '--plugins');
+  const pluginsArg = pluginsArgIdx !== -1 ? process.argv[pluginsArgIdx + 1] : undefined;
+  const pluginOverride = pluginsArg
+    ? pluginsArg
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : undefined;
 
   if (noSBOM) console.log('[INFO] SBOM generation skipped (--no-sbom flag)');
   if (sbomStrict)
     console.log('[INFO] SBOM strict mode enabled -- build will fail if SBOM generation errors');
   if (noImageOptimization)
     console.log('[INFO] Image optimization skipped (--no-image-optimization flag)');
+  if (noPluginDiscovery)
+    console.log('[INFO] Plugin auto-discovery disabled (--no-plugin-discovery flag)');
+  if (pluginOverride) console.log(`[INFO] Plugin discovery override: ${pluginOverride.join(', ')}`);
 
   if (watchMode) {
     const { runWatch } = require('./watch');
@@ -186,6 +206,8 @@ if (require.main === module) {
       try {
         await runPrebuild({
           imageOptimization: noImageOptimization ? false : undefined,
+          pluginDiscovery: noPluginDiscovery ? false : undefined,
+          pluginOverride,
         });
       } catch (err) {
         console.error(`ERROR: ${(err as Error).message}`);

--- a/packages/build-scripts/test/prebuild-plugin-discovery.test.ts
+++ b/packages/build-scripts/test/prebuild-plugin-discovery.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Integration tests for plugin auto-discovery (feat/prebuild-plugin-discovery).
+ *
+ * All tests use real temp directories and real file system ops — no mocks.
+ * See CONTRIBUTING.md "Testing Philosophy" for why.
+ *
+ * Tier A: Convention discovery (@stackwright-pro/build-scripts-plugins)
+ * Tier B: Config discovery (prebuild.plugins in stackwright.yml)
+ * CLI:    --plugins override / --no-plugin-discovery
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+import { runPrebuild } from '../src/prebuild';
+import { discoverPlugins, CANONICAL_PRO_BUNDLE } from '../src/compile/discover';
+
+// ---------------------------------------------------------------------------
+// Zod path resolution — fake plugins need real Zod schemas.
+//
+// CJS plugins in temp node_modules can't find zod on their own, so we
+// symlink the real zod package into each fake project's node_modules.
+// We find zod's path relative to THIS test file's location.
+// ---------------------------------------------------------------------------
+
+const _req = createRequire(import.meta.url);
+const ZOD_PACKAGE_DIR = path.dirname(_req.resolve('zod/package.json'));
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a minimal valid project root in a temp dir.
+ * The stackwright.yml satisfies siteConfigSchema (title + navigation + appBar required).
+ */
+function makeTempProject(overrides: { siteYaml?: string } = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-discovery-test-'));
+  const siteYaml =
+    overrides.siteYaml ?? `title: Test Site\nnavigation: []\nappBar:\n  titleText: Test Site\n`;
+  fs.writeFileSync(path.join(dir, 'stackwright.yml'), siteYaml);
+  fs.mkdirSync(path.join(dir, 'pages'), { recursive: true });
+
+  // Symlink the real zod package so fake CJS plugins can require('zod')
+  const zodDest = path.join(dir, 'node_modules', 'zod');
+  fs.mkdirSync(path.join(dir, 'node_modules'), { recursive: true });
+  if (!fs.existsSync(zodDest)) {
+    fs.symlinkSync(ZOD_PACKAGE_DIR, zodDest, 'dir');
+  }
+
+  return dir;
+}
+
+/**
+ * Write a content.yml at the root page (slug = null) or a named slug.
+ */
+function writePageYaml(projectRoot: string, yaml: string, slug?: string): void {
+  const dir = slug ? path.join(projectRoot, 'pages', slug) : path.join(projectRoot, 'pages');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'content.yml'), yaml);
+}
+
+/**
+ * Install a fake CommonJS plugin package into node_modules of a project.
+ *
+ * @param projectRoot - The temp project root.
+ * @param packageName - e.g. '@stackwright-pro/build-scripts-plugins'
+ * @param indexJs     - Content of the package's index.js (CJS).
+ */
+function installFakePackage(projectRoot: string, packageName: string, indexJs: string): void {
+  // Handle scoped packages (@scope/name → node_modules/@scope/name)
+  const pkgDir = path.join(projectRoot, 'node_modules', ...packageName.split('/'));
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: packageName, main: './index.js' }, null, 2)
+  );
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), indexJs);
+}
+
+// ---------------------------------------------------------------------------
+// Fake CJS plugin module templates
+//
+// These use real Zod schemas (require('zod') works because we symlinked zod
+// into the temp project's node_modules in makeTempProject).
+// ---------------------------------------------------------------------------
+
+/** Fake Pro bundle — exports proPlugins with 'fake_pulse' schema (Tier A). */
+const FAKE_PRO_BUNDLE_INDEX_JS = `\
+'use strict';
+const z = require('zod');
+const fakeSchema = z.object({ type: z.literal('fake_pulse'), label: z.string() }).passthrough();
+const fakePlugin = {
+  name: 'fake-pulse-plugin',
+  knownContentTypeKeys: ['fake_pulse'],
+  contentItemSchemas: [fakeSchema],
+};
+module.exports = { proPlugins: [fakePlugin] };
+`;
+
+/** Fake third-party plugin — exports via `plugins` key with 'third_party_widget'. */
+const FAKE_THIRD_PARTY_INDEX_JS = `\
+'use strict';
+const z = require('zod');
+const fakeSchema = z.object({ type: z.literal('third_party_widget'), label: z.string() }).passthrough();
+const fakePlugin = {
+  name: 'fake-third-party-plugin',
+  knownContentTypeKeys: ['third_party_widget'],
+  contentItemSchemas: [fakeSchema],
+};
+module.exports = { plugins: [fakePlugin] };
+`;
+
+// ---------------------------------------------------------------------------
+// Test content fixtures
+// ---------------------------------------------------------------------------
+
+const MINIMAL_PAGE_OSS = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: text_block
+      label: intro
+      textBlocks: []
+`;
+
+const PAGE_WITH_FAKE_PULSE = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: fake_pulse
+      label: my-widget
+`;
+
+const PAGE_WITH_DATA_TABLE = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: data_table_pulse
+      label: my-table
+`;
+
+const PAGE_WITH_THIRD_PARTY = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: third_party_widget
+      label: my-widget
+`;
+
+// ---------------------------------------------------------------------------
+// Test 2.1: Convention-tier discovery succeeds
+// ---------------------------------------------------------------------------
+
+describe('Tier A — convention discovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('2.1: discovers @stackwright-pro/build-scripts-plugins and validates fake_pulse without warnings', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_INDEX_JS);
+    writePageYaml(projectRoot, PAGE_WITH_FAKE_PULSE);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // unknownContentTypes: 'warn' so validation errors become warnings not throws
+    await runPrebuild({ projectRoot, unknownContentTypes: 'warn' });
+
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0]));
+    // Plugin was discovered and schemas registered — no "Unknown content type" or
+    // "Invalid content" warnings about fake_pulse expected
+    const hasContentWarning = warnMessages.some(
+      (m) =>
+        (m.includes('Unknown content type') || m.includes('Invalid content')) &&
+        m.includes('fake_pulse')
+    );
+    expect(hasContentWarning).toBe(false);
+
+    // The output JSON must be written
+    const rootJson = path.join(projectRoot, 'public', 'stackwright-content', '_root.json');
+    expect(fs.existsSync(rootJson)).toBe(true);
+  });
+
+  it('2.1b: CANONICAL_PRO_BUNDLE const matches the expected package name', () => {
+    expect(CANONICAL_PRO_BUNDLE).toBe('@stackwright-pro/build-scripts-plugins');
+  });
+
+  it('2.1c: discovery log line is emitted when Pro bundle is found', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_INDEX_JS);
+    writePageYaml(projectRoot, MINIMAL_PAGE_OSS);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await runPrebuild({ projectRoot });
+
+    const logMessages = logSpy.mock.calls.map((args) => String(args[0]));
+    const hasConventionLog = logMessages.some(
+      (m) => m.includes(CANONICAL_PRO_BUNDLE) && m.includes('convention')
+    );
+    expect(hasConventionLog).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2.2: OSS-only (no Pro bundle) — clean fallback
+// ---------------------------------------------------------------------------
+
+describe('Tier A — OSS-only fallback', () => {
+  it('2.2: no Pro bundle in node_modules → prebuild completes cleanly with OSS content', async () => {
+    const projectRoot = makeTempProject();
+    // No Pro package installed. Use a known-good OSS content type.
+    writePageYaml(projectRoot, MINIMAL_PAGE_OSS);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(runPrebuild({ projectRoot })).resolves.not.toThrow();
+
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0]));
+    // No plugin-resolution warnings expected
+    const hasPluginWarning = warnMessages.some(
+      (m) => m.includes('build-scripts-plugins') || m.includes('no recognized export')
+    );
+    expect(hasPluginWarning).toBe(false);
+    vi.restoreAllMocks();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2.3: OSS-only with unknown pro type — warning IS preserved (regression guard)
+// ---------------------------------------------------------------------------
+
+describe('Tier A — unknown type regression guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('2.3: no Pro bundle + data_table_pulse → unknown-type warning still emitted (OSS UX unchanged)', async () => {
+    const projectRoot = makeTempProject();
+    // No Pro package. Use the actual Pro type name to prove it still warns.
+    writePageYaml(projectRoot, PAGE_WITH_DATA_TABLE);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runPrebuild({ projectRoot, unknownContentTypes: 'warn' });
+
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0]));
+    // Some kind of content error should be present for the unknown pro type
+    const hasContentWarning = warnMessages.some(
+      (m) => m.includes('data_table_pulse') || m.includes('Invalid content')
+    );
+    expect(hasContentWarning).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2.4: Explicit plugins: [] overrides discovery
+// ---------------------------------------------------------------------------
+
+describe('explicit plugins array overrides discovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('2.4: plugins: [] skips discovery even when Pro bundle is present in node_modules', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_INDEX_JS);
+    writePageYaml(projectRoot, PAGE_WITH_FAKE_PULSE);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Explicit empty array → discovery must be skipped
+    await runPrebuild({ projectRoot, plugins: [], unknownContentTypes: 'warn' });
+
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0]));
+    // Discovery was bypassed, so fake_pulse should be unrecognized → some content warning
+    const hasContentWarning = warnMessages.some(
+      (m) => m.includes('fake_pulse') || m.includes('Invalid content')
+    );
+    expect(hasContentWarning).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2.5: Config-tier discovery via stackwright.yml prebuild.plugins
+// ---------------------------------------------------------------------------
+
+describe('Tier B — config discovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('2.5: prebuild.plugins in stackwright.yml loads third-party plugin and validates type', async () => {
+    const projectRoot = makeTempProject({
+      siteYaml: [
+        'title: Test Site',
+        'navigation: []',
+        'appBar:',
+        '  titleText: Test Site',
+        'prebuild:',
+        '  plugins:',
+        '    - fake-third-party-plugin',
+      ].join('\n'),
+    });
+    installFakePackage(projectRoot, 'fake-third-party-plugin', FAKE_THIRD_PARTY_INDEX_JS);
+    writePageYaml(projectRoot, PAGE_WITH_THIRD_PARTY);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runPrebuild({ projectRoot, unknownContentTypes: 'warn' });
+
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0]));
+    // Plugin loaded via config tier — no content warnings for third_party_widget
+    const hasContentWarning = warnMessages.some(
+      (m) =>
+        (m.includes('Unknown content type') || m.includes('Invalid content')) &&
+        m.includes('third_party_widget')
+    );
+    expect(hasContentWarning).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2.6: Config-tier typo → hard error
+// ---------------------------------------------------------------------------
+
+describe('Tier B — hard error on typo', () => {
+  it('2.6: nonexistent plugin in prebuild.plugins throws with package name', async () => {
+    const projectRoot = makeTempProject({
+      siteYaml: [
+        'title: Test Site',
+        'navigation: []',
+        'appBar:',
+        '  titleText: Test Site',
+        'prebuild:',
+        '  plugins:',
+        '    - nonexistent-plugin-xyz',
+      ].join('\n'),
+    });
+    writePageYaml(projectRoot, MINIMAL_PAGE_OSS);
+
+    await expect(runPrebuild({ projectRoot })).rejects.toThrow('nonexistent-plugin-xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2.7: pluginOverride skips Tier A even when Pro bundle is present
+// ---------------------------------------------------------------------------
+
+describe('pluginOverride option', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('2.7: pluginOverride loads named packages and skips convention tier', async () => {
+    const projectRoot = makeTempProject();
+    // Install BOTH the pro bundle AND the third-party plugin.
+    // Override should load only the third-party one.
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_INDEX_JS);
+    installFakePackage(projectRoot, 'fake-third-party-plugin', FAKE_THIRD_PARTY_INDEX_JS);
+
+    // Use a type only the third-party plugin knows (NOT fake_pulse from pro bundle)
+    writePageYaml(projectRoot, PAGE_WITH_THIRD_PARTY);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runPrebuild({
+      projectRoot,
+      pluginOverride: ['fake-third-party-plugin'],
+      unknownContentTypes: 'warn',
+    });
+
+    // third_party_widget should be known (no content warning)
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0]));
+    const hasContentWarning = warnMessages.some(
+      (m) =>
+        (m.includes('Unknown content type') || m.includes('Invalid content')) &&
+        m.includes('third_party_widget')
+    );
+    expect(hasContentWarning).toBe(false);
+
+    // Convention tier log line for CANONICAL_PRO_BUNDLE should NOT appear
+    const logMessages = logSpy.mock.calls.map((args) => String(args[0]));
+    const hasConventionLog = logMessages.some(
+      (m) => m.includes(CANONICAL_PRO_BUNDLE) && m.includes('convention')
+    );
+    expect(hasConventionLog).toBe(false);
+
+    // Override log line SHOULD appear
+    const hasOverrideLog = logMessages.some(
+      (m) => m.includes('fake-third-party-plugin') && m.includes('override')
+    );
+    expect(hasOverrideLog).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverPlugins low-level API tests
+// ---------------------------------------------------------------------------
+
+describe('discoverPlugins low-level API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns [] immediately when enabled is false', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_INDEX_JS);
+
+    const result = await discoverPlugins(projectRoot, { enabled: false });
+    expect(result).toEqual([]);
+  });
+
+  it('de-duplicates plugins with the same name', async () => {
+    // Install the pro bundle as the convention tier, AND add it again via config tier
+    // under a different package name but same plugin.name — dedup should keep only one.
+    const dualPlugin = `\
+'use strict';
+module.exports = {
+  proPlugins: [{ name: 'shared-plugin', knownContentTypeKeys: [] }],
+  plugins: [{ name: 'shared-plugin', knownContentTypeKeys: [] }],
+};
+`;
+    const projectRoot = makeTempProject({
+      siteYaml: [
+        'title: Test Site',
+        'navigation: []',
+        'appBar:',
+        '  titleText: Test Site',
+        'prebuild:',
+        '  plugins:',
+        '    - fake-third-party-plugin',
+      ].join('\n'),
+    });
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, dualPlugin);
+    installFakePackage(projectRoot, 'fake-third-party-plugin', dualPlugin);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const result = await discoverPlugins(projectRoot);
+
+    // Should only have ONE instance of 'shared-plugin'
+    const names = result.map((p) => p.name);
+    expect(names.filter((n) => n === 'shared-plugin').length).toBe(1);
+
+    // Debug log should have fired about the duplicate
+    const logMessages = logSpy.mock.calls.map((args) => String(args[0]));
+    expect(logMessages.some((m) => m.includes('Skipping duplicate plugin'))).toBe(true);
+  });
+
+  it('--no-plugin-discovery: pluginDiscovery false returns [] even with Pro bundle present', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_INDEX_JS);
+
+    const result = await discoverPlugins(projectRoot, { enabled: false });
+    expect(result).toHaveLength(0);
+  });
+});

--- a/packages/types/schemas/site-config-schema.json
+++ b/packages/types/schemas/site-config-schema.json
@@ -655,6 +655,26 @@
         "supported"
       ],
       "additionalProperties": false
+    },
+    "prebuild": {
+      "type": "object",
+      "properties": {
+        "plugins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "unknownContentTypes": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warn",
+            "ignore"
+          ]
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/packages/types/src/types/plugin.ts
+++ b/packages/types/src/types/plugin.ts
@@ -199,4 +199,29 @@ export interface PrebuildOptions {
    * This flag overrides `imageOptimization.enabled` in stackwright.yml.
    */
   imageOptimization?: boolean;
+
+  /**
+   * Enable or disable automatic plugin discovery from node_modules.
+   *
+   * When `true` (default, i.e. undefined), the prebuild CLI will attempt
+   * to resolve well-known plugin bundles (e.g. @stackwright-pro/build-scripts-plugins)
+   * from the project's node_modules. Set to `false` or use `--no-plugin-discovery`
+   * to disable auto-discovery (useful in environments where the resolution would
+   * be slow or unreliable).
+   *
+   * Has no effect when `plugins` is explicitly provided.
+   */
+  pluginDiscovery?: boolean;
+
+  /**
+   * Explicit list of plugin package names to load (overrides Tier A convention
+   * discovery AND stackwright.yml `prebuild.plugins` config). Mirrors the
+   * `--plugins pkg-a,pkg-b` CLI flag.
+   *
+   * Each name is resolved from the project's node_modules via the same
+   * `createRequire` trick as Tier B config discovery.
+   *
+   * Has no effect when `plugins` is explicitly provided.
+   */
+  pluginOverride?: string[];
 }

--- a/packages/types/src/types/siteConfig.ts
+++ b/packages/types/src/types/siteConfig.ts
@@ -214,6 +214,29 @@ export const localesConfigSchema = z.object({
   supported: z.array(z.string()).min(1),
 });
 
+/**
+ * Prebuild pipeline configuration (optional section in stackwright.yml).
+ *
+ * Controls build-time plugin discovery and validation behavior.
+ * The `unknownContentTypes` field is schema-only in this release —
+ * behavior threading is tracked separately.
+ */
+export const prebuildConfigSchema = z
+  .object({
+    /**
+     * Additional plugin package names to load during prebuild (Tier B discovery).
+     * Each name must be resolvable from the project's node_modules.
+     * Typos here are hard errors — the build fails loudly.
+     */
+    plugins: z.array(z.string()).optional(),
+    /**
+     * How to handle unknown content types encountered during validation.
+     * Schema-only — behavior threading is out of scope for this release.
+     */
+    unknownContentTypes: z.enum(['error', 'warn', 'ignore']).optional(),
+  })
+  .optional();
+
 export const siteConfigSchema = z.object({
   title: z.string(),
   meta: siteMetaSchema.optional(),
@@ -235,6 +258,8 @@ export const siteConfigSchema = z.object({
   imageOptimization: imageOptimizationConfigSchema.optional(),
   /** Optional locale configuration for multi-language content support. */
   locales: localesConfigSchema.optional(),
+  /** Optional prebuild pipeline configuration for plugin discovery and validation. */
+  prebuild: prebuildConfigSchema,
 });
 
 export type SiteMeta = z.infer<typeof siteMetaSchema>;
@@ -247,4 +272,5 @@ export type SearchConfig = z.infer<typeof searchConfigSchema>;
 export type FontsConfig = z.infer<typeof fontsConfigSchema>;
 export type ImageOptimizationConfig = z.infer<typeof imageOptimizationConfigSchema>;
 export type LocalesConfig = z.infer<typeof localesConfigSchema>;
+export type PrebuildConfig = z.infer<typeof prebuildConfigSchema>;
 export type SiteConfig = z.infer<typeof siteConfigSchema>;


### PR DESCRIPTION
## Summary

Adds three-tier plugin auto-discovery to `stackwright-prebuild` so Pro content types (`data_table_pulse`, `metric_card_pulse`, etc.) validate correctly during prebuild — matching the fidelity of `next dev` runtime.

**Root cause fixed:** the CLI binary previously invoked `runPrebuild()` with an empty `plugins` array, so `validatePageContent()` saw no schemas for Pro types and emitted `[WARN] Unknown content type data_table_pulse` even when `@stackwright-pro/build-scripts-plugins` was correctly installed.

## Discovery tiers

1. **Convention** — attempts `require('@stackwright-pro/build-scripts-plugins')` from the project root. Silent soft-fail if absent (normal OSS case).
2. **Config** — reads `prebuild.plugins: string[]` from `stackwright.yml`. Hard-fail with a clear error on typos.
3. **Explicit override** — `runPrebuild({ plugins })` bypasses discovery entirely. Preserves existing programmatic wrappers and test injection.

## CLI flags

- `--no-plugin-discovery` — disable all auto-discovery
- `--plugins pkg-a,pkg-b` — override list, skips Tier A/B

## Backward compatibility

- `runPrebuild({ plugins: [...] })` → unchanged (explicit array wins)
- `runPrebuild({ plugins: [] })` → unchanged (empty array = "explicitly no plugins")
- `runPrebuild()` with no `plugins` field → NEW: discovery runs

## Testing

12 integration tests with real fixtures under `test/fixtures/discovery/`:
- Convention tier discovers Pro bundle from tmp `node_modules`
- OSS-only case: clean fallback, no warnings
- OSS-only with Pro-style yaml: warning IS preserved (regression guard)
- Explicit `plugins: []` overrides discovery
- Config-tier discovery via `stackwright.yml`
- Config-tier typo throws with clear error naming the bad package
- `--plugins` CLI override

**278/278 tests green.** Manual empty-folder smoke test clean.

## Files changed

- `packages/build-scripts/src/compile/discover.ts` — new
- `packages/build-scripts/src/compile/context.ts` — adds `discoverAndAttachPlugins()`
- `packages/build-scripts/src/prebuild.ts` — wires discovery + adds CLI flags
- `packages/types/src/types/plugin.ts` — `pluginDiscovery` + `pluginOverride` options
- `packages/types/src/types/siteConfig.ts` — optional `prebuild` block
- `packages/build-scripts/test/prebuild-plugin-discovery.test.ts` — new

## Deferred to follow-up PRs

- `packages/build-scripts/AGENTS.md` docs section on Plugin Discovery
- `launch-stackwright` scaffolding update (stop generating manual wrapper scripts)
- `unknownContentTypes` yml threading (schema is added, behavior wiring is separate)
- Pre-existing `pnpm format:check` failures on 10 files — cleanup PR (per kennel decision rule, not fixed inline)

## Changeset

Skipped for this PR — planning-agent will handle release prep separately.