### PR TITLE
fix(build-scripts): dedup plugin-declared type warnings + wire prebuild.unknownContentTypes yml

### DIFF
--- a/.changeset/prebuild-warning-dedup-and-uct-config.md
+++ b/.changeset/prebuild-warning-dedup-and-uct-config.md
@@ -1,0 +1,41 @@
+---
+'@stackwright/build-scripts': patch
+---
+
+**fix(build-scripts): dedup plugin-declared type warnings + thread prebuild.unknownContentTypes from yml**
+
+Closes swp-3r93. Wires the #529 leftover.
+
+### Change 1 — swp-3r93: dedup plugin-declared content type warnings
+
+Previously, every page using a plugin-declared content type (e.g. `data_table_pulse`) emitted its own `[WARN]` line — 22 pages × pulse types = 22 identical noisy lines in DHL builds.
+
+**New behaviour:** a single `[INFO]` summary is emitted after all pages are processed:
+
+```
+  [INFO] Plugin-declared content types in use across 3 page(s):
+    - fake_pulse (from: fake-pulse-plugin)
+  App code must call registerContentType() at runtime for each of these types.
+  (Build-time schema validation succeeded via plugin discovery — this is a runtime reminder.)
+```
+
+Key messaging improvements:
+- Downgraded from `console.warn` to `console.log` with `[INFO]` prefix — this is not an error
+- Makes clear that build-time validation already passed (via #529 plugin discovery)
+- The message is a runtime registration reminder, not a build failure
+
+Genuine validation errors (`[WARN] Invalid content ...`) are unaffected — they still fire per-page.
+
+### Change 2 — thread `prebuild.unknownContentTypes` from `stackwright.yml`
+
+The `prebuild.unknownContentTypes` field was added to the schema in #529 but never wired. It now works:
+
+```yaml
+# stackwright.yml
+prebuild:
+  unknownContentTypes: warn   # or 'error' (default) or 'ignore'
+```
+
+**Precedence:** explicit `runPrebuild({ unknownContentTypes })` option > yml value > `'error'` default.
+
+Implementation: `compileAll` peeks at the yml before any sink runs and fills in `ctx.unknownContentTypes` if the caller didn't pass an explicit value. The default in `createCompileContext` was changed from `'error'` to `undefined` so the "was it explicit?" signal is preserved until resolution.

--- a/packages/build-scripts/src/compile/context.ts
+++ b/packages/build-scripts/src/compile/context.ts
@@ -22,8 +22,14 @@ export interface CompileContext {
   generatedDir: string;
   /** Registered prebuild plugins. */
   plugins: PrebuildPlugin[];
-  /** How to handle unknown content type errors during page validation. */
-  unknownContentTypes: 'error' | 'warn' | 'ignore';
+  /**
+   * How to handle unknown content type errors during page validation.
+   *
+   * `undefined` means "not yet resolved" — `compileAll` fills in the yml value
+   * or falls back to `'error'` before any sink runs. Direct callers of
+   * `compilePages` should always provide an explicit value.
+   */
+  unknownContentTypes: 'error' | 'warn' | 'ignore' | undefined;
   /** Whether image optimization is enabled (resolved from CLI flag + site config). */
   imageOptimizationEnabled: boolean;
 }
@@ -36,10 +42,13 @@ export function createCompileContext(options?: string | PrebuildOptions): Compil
   const projectRoot =
     typeof options === 'string' ? options : (options?.projectRoot ?? process.cwd());
   const plugins = typeof options === 'object' && options !== null ? (options.plugins ?? []) : [];
+  // Keep `undefined` when the caller didn't pass an explicit value.
+  // `compileAll` resolves it from `prebuild.unknownContentTypes` in stackwright.yml
+  // (or falls back to `'error'`) before any sink runs.
   const unknownContentTypes =
-    typeof options === 'object' && options !== null
+    typeof options === 'object' && options !== null && 'unknownContentTypes' in options
       ? (options.unknownContentTypes ?? 'error')
-      : 'error';
+      : undefined;
   const imageOptimizationEnabled =
     typeof options === 'object' && options !== null && options.imageOptimization !== undefined
       ? options.imageOptimization

--- a/packages/build-scripts/src/compile/index.ts
+++ b/packages/build-scripts/src/compile/index.ts
@@ -56,7 +56,9 @@ export type { DiscoverPluginsOptions } from './discover';
 // compileAll
 // ---------------------------------------------------------------------------
 
+import fs from 'fs';
 import path from 'path';
+import yaml from 'js-yaml';
 import { compileSite } from './site';
 import { compileTheme } from './theme';
 import { compileFileCollections } from './collections';
@@ -65,6 +67,34 @@ import { compileIcons } from './icons';
 import { compileFonts } from './fonts';
 import { toPluginContext } from './context';
 import type { CompileContext } from './context';
+
+/**
+ * Peek at `stackwright.yml` (without full schema validation) to extract the
+ * `prebuild.unknownContentTypes` value. Used by `compileAll` to resolve the
+ * default before any sink runs, when the caller didn't pass an explicit value.
+ *
+ * Returns `undefined` if the field is absent, the file doesn't exist, or the
+ * value isn't one of the three valid enum strings.
+ */
+function peekYmlUCT(projectRoot: string): 'error' | 'warn' | 'ignore' | undefined {
+  const candidates = ['stackwright.yml', 'stackwright.yaml'];
+  for (const candidate of candidates) {
+    const ymlPath = path.join(projectRoot, candidate);
+    if (!fs.existsSync(ymlPath)) continue;
+    try {
+      const raw = yaml.load(fs.readFileSync(ymlPath, 'utf8'));
+      if (!raw || typeof raw !== 'object') return undefined;
+      const prebuild = (raw as Record<string, unknown>).prebuild;
+      if (!prebuild || typeof prebuild !== 'object') return undefined;
+      const uct = (prebuild as Record<string, unknown>).unknownContentTypes;
+      if (uct === 'error' || uct === 'warn' || uct === 'ignore') return uct;
+    } catch {
+      // Malformed yml — compileSite will give a proper error later
+    }
+    return undefined;
+  }
+  return undefined;
+}
 
 /**
  * Run all compile steps in the correct order.
@@ -81,6 +111,12 @@ import type { CompileContext } from './context';
  * 9. afterBuild plugin hooks
  */
 export async function compileAll(ctx: CompileContext): Promise<void> {
+  // Resolve unknownContentTypes if the caller didn't pass an explicit value.
+  // Precedence: explicit option > stackwright.yml prebuild.unknownContentTypes > 'error'
+  if (ctx.unknownContentTypes === undefined) {
+    ctx.unknownContentTypes = peekYmlUCT(ctx.projectRoot) ?? 'error';
+  }
+
   // 1. Site config (must run first; plugins need siteConfig in beforeBuild)
   // Synchronous — file I/O only.
   const { processedConfig } = compileSite(ctx);

--- a/packages/build-scripts/src/compile/pages.ts
+++ b/packages/build-scripts/src/compile/pages.ts
@@ -4,16 +4,8 @@ import yaml from 'js-yaml';
 import { z } from 'zod';
 import { validatePageContent } from '@stackwright/types/validation';
 import type { PrebuildPlugin } from '@stackwright/types';
-import {
-  copyIfNewer,
-  rewritePaths,
-  isColocatablePath,
-  isVideoPath,
-} from './path-utils';
-import {
-  processImageOptimization,
-  type ImageManifest,
-} from '../image-optimizer';
+import { copyIfNewer, rewritePaths, isColocatablePath, isVideoPath } from './path-utils';
+import { processImageOptimization, type ImageManifest } from '../image-optimizer';
 import type { ImageOptimizationConfig } from '@stackwright/types';
 import type { CompileContext } from './context';
 
@@ -48,7 +40,11 @@ export function findContentFiles(dir: string, baseSlug = ''): ContentFile[] {
       const subSlug = baseSlug ? `${baseSlug}/${entry.name}` : entry.name;
       results.push(...findContentFiles(path.join(dir, entry.name), subSlug));
     } else if (entry.name === 'content.yml' || entry.name === 'content.yaml') {
-      results.push({ slug: baseSlug || null, filePath: path.join(dir, entry.name), contentDir: dir });
+      results.push({
+        slug: baseSlug || null,
+        filePath: path.join(dir, entry.name),
+        contentDir: dir,
+      });
     } else {
       const localeMatch = entry.name.match(/^content\.([^.]+)\.(yml|yaml)$/);
       if (localeMatch) {
@@ -357,6 +353,12 @@ export function compilePages(
     console.warn('  WARNING: No content.yml files found in pages/');
   }
 
+  // Accumulator for the single post-loop summary (swp-3r93)
+  // type → set of plugin names declaring it
+  const pluginTypeUsageByType = new Map<string, Set<string>>();
+  // page labels that used any plugin type (for page count in summary)
+  const pagesUsingPluginTypes = new Set<string>();
+
   for (const { slug, filePath, contentDir, locale } of contentFiles) {
     const label = slug ?? '(root)';
     const rawContent = yaml.load(fs.readFileSync(filePath, 'utf8'));
@@ -381,18 +383,20 @@ export function compilePages(
       }
     }
 
-    // Warn when plugin-declared types appear in pages
+    // Accumulate plugin-declared type usage for the single post-loop summary (swp-3r93).
+    // Build-time schema validation already succeeded; this is a runtime-registration reminder.
     if (pageValidation.valid && pluginKnownTypes.length > 0) {
       const usedTypes = collectContentTypes(normalizedContent);
       const pluginTypesUsed = [...usedTypes].filter((t) => pluginKnownTypes.includes(t));
       if (pluginTypesUsed.length > 0) {
-        const declaringPlugins = plugins
-          .filter((p) => (p.knownContentTypeKeys ?? []).some((k) => pluginTypesUsed.includes(k)))
-          .map((p) => p.name);
-        console.warn(
-          `  [WARN] ${label}: uses ${pluginTypesUsed.length} plugin-declared type(s) [${declaringPlugins.join(', ')}]: ${pluginTypesUsed.join(', ')}\n` +
-            `     Ensure registerContentType() is called in your app for each of these types.`
-        );
+        pagesUsingPluginTypes.add(label);
+        for (const type of pluginTypesUsed) {
+          if (!pluginTypeUsageByType.has(type)) {
+            pluginTypeUsageByType.set(type, new Set());
+          }
+          const declaring = plugins.filter((p) => (p.knownContentTypeKeys ?? []).includes(type));
+          for (const p of declaring) pluginTypeUsageByType.get(type)!.add(p.name);
+        }
       }
     }
 
@@ -418,6 +422,21 @@ export function compilePages(
     const logPath = locale ? `${locale}/${outFile}` : outFile;
     const logLabel = locale ? `${label} [${locale}]` : label;
     console.log(`  OK ${logPath}  (${logLabel})`);
+  }
+
+  // Post-loop: emit a single runtime-reminder summary for plugin-declared types (swp-3r93).
+  // If the accumulator is empty, zero pages used plugin types — nothing to say.
+  if (pluginTypeUsageByType.size > 0) {
+    const typesGrouped = [...pluginTypeUsageByType.entries()]
+      .map(([type, declaringSet]) => `${type} (from: ${[...declaringSet].sort().join(', ')})`)
+      .sort();
+    console.log(
+      `\n  [INFO] Plugin-declared content types in use across ${pagesUsingPluginTypes.size} page(s):\n` +
+        typesGrouped.map((line) => `    - ${line}`).join('\n') +
+        '\n' +
+        `  App code must call registerContentType() at runtime for each of these types.\n` +
+        `  (Build-time schema validation succeeded via plugin discovery — this is a runtime reminder.)`
+    );
   }
 
   // Return resolved imageOptConfig so compileAll can run the async image pass
@@ -472,4 +491,3 @@ export async function optimizeImages(
     console.log('  [OK] Enriched content JSONs with blur placeholders');
   }
 }
-

--- a/packages/build-scripts/test/plugin-hooks.test.ts
+++ b/packages/build-scripts/test/plugin-hooks.test.ts
@@ -122,7 +122,7 @@ describe('content type warnings and unknownContentTypes option', () => {
     vi.restoreAllMocks();
   });
 
-  it('Gap 1: plugin-declared types trigger a warning', async () => {
+  it('Gap 1: plugin-declared types emit [INFO] summary (swp-3r93: deduped, not per-page warn)', async () => {
     const projectRoot = makeTempProject();
     const plugin = {
       name: 'pro-content',
@@ -139,16 +139,22 @@ describe('content type warnings and unknownContentTypes option', () => {
 `
     );
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await runPrebuild({ projectRoot, plugins: [plugin] });
 
-    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
-    expect(warnCalls.some((msg) => msg.includes('custom_widget'))).toBe(true);
-    expect(warnCalls.some((msg) => msg.includes('registerContentType'))).toBe(true);
+    // New behavior: single [INFO] summary via console.log, NOT per-page console.warn
+    const logCalls = logSpy.mock.calls.map((args) => String(args[0]));
+    const infoSummary = logCalls.filter((msg) =>
+      msg.includes('[INFO] Plugin-declared content types')
+    );
+    expect(infoSummary.length).toBe(1);
+    expect(infoSummary[0]).toContain('custom_widget');
+    expect(infoSummary[0]).toContain('registerContentType');
   });
 
-  it('Gap 1: core types do NOT trigger the plugin warning', async () => {
+  it('Gap 1: core types do NOT trigger the plugin [INFO] summary', async () => {
     const projectRoot = makeTempProject();
     const plugin = {
       name: 'pro-content',
@@ -166,12 +172,15 @@ describe('content type warnings and unknownContentTypes option', () => {
 `
     );
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await runPrebuild({ projectRoot, plugins: [plugin] });
 
-    const warnCalls = warnSpy.mock.calls.map((args) => String(args[0]));
-    expect(warnCalls.some((msg) => msg.includes('registerContentType'))).toBe(false);
+    const logCalls = logSpy.mock.calls.map((args) => String(args[0]));
+    expect(logCalls.some((msg) => msg.includes('[INFO] Plugin-declared content types'))).toBe(
+      false
+    );
   });
 
   it('Gap 2: unknownContentTypes "warn" logs but does not throw', async () => {

--- a/packages/build-scripts/test/prebuild-plugin-type-warnings.test.ts
+++ b/packages/build-scripts/test/prebuild-plugin-type-warnings.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Integration tests for plugin-declared content type warning dedup (swp-3r93).
+ *
+ * Verifies that the per-page [WARN] spam is replaced by a single [INFO]
+ * post-loop summary, while genuine validation errors still fire per-page.
+ *
+ * All tests use real temp directories — no mocks on fs/module resolution.
+ * See CONTRIBUTING.md "Testing Philosophy" for why.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+import { runPrebuild } from '../src/prebuild';
+import { CANONICAL_PRO_BUNDLE } from '../src/compile/discover';
+
+// ---------------------------------------------------------------------------
+// Zod symlink — fake CJS plugins need real zod in their resolution chain
+// ---------------------------------------------------------------------------
+
+const _req = createRequire(import.meta.url);
+const ZOD_PACKAGE_DIR = path.dirname(_req.resolve('zod/package.json'));
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeTempProject(overrides: { siteYaml?: string } = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-warn-dedup-test-'));
+  const siteYaml =
+    overrides.siteYaml ?? `title: Test Site\nnavigation: []\nappBar:\n  titleText: Test Site\n`;
+  fs.writeFileSync(path.join(dir, 'stackwright.yml'), siteYaml);
+  fs.mkdirSync(path.join(dir, 'pages'), { recursive: true });
+
+  // Symlink real zod so fake CJS plugins can require('zod')
+  const zodDest = path.join(dir, 'node_modules', 'zod');
+  fs.mkdirSync(path.join(dir, 'node_modules'), { recursive: true });
+  if (!fs.existsSync(zodDest)) {
+    fs.symlinkSync(ZOD_PACKAGE_DIR, zodDest, 'dir');
+  }
+
+  return dir;
+}
+
+function writePageYaml(projectRoot: string, yaml: string, slug?: string): void {
+  const dir = slug ? path.join(projectRoot, 'pages', slug) : path.join(projectRoot, 'pages');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'content.yml'), yaml);
+}
+
+function installFakePackage(projectRoot: string, packageName: string, indexJs: string): void {
+  const pkgDir = path.join(projectRoot, 'node_modules', ...packageName.split('/'));
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: packageName, main: './index.js' }, null, 2)
+  );
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), indexJs);
+}
+
+// ---------------------------------------------------------------------------
+// Fake plugin templates
+// ---------------------------------------------------------------------------
+
+/**
+ * A fake Pro bundle exposing ONE plugin type: `fake_pulse`.
+ */
+const FAKE_PRO_BUNDLE_SINGLE = `\
+'use strict';
+const z = require('zod');
+const fakeSchema = z.object({ type: z.literal('fake_pulse'), label: z.string() }).passthrough();
+const fakePlugin = {
+  name: 'fake-pulse-plugin',
+  knownContentTypeKeys: ['fake_pulse'],
+  contentItemSchemas: [fakeSchema],
+};
+module.exports = { proPlugins: [fakePlugin] };
+`;
+
+/**
+ * A fake Pro bundle exposing TWO plugin types: `fake_pulse_a` and `fake_pulse_b`.
+ */
+const FAKE_PRO_BUNDLE_DUAL = `\
+'use strict';
+const z = require('zod');
+const schemaA = z.object({ type: z.literal('fake_pulse_a'), label: z.string() }).passthrough();
+const schemaB = z.object({ type: z.literal('fake_pulse_b'), label: z.string() }).passthrough();
+const fakePlugin = {
+  name: 'fake-multi-plugin',
+  knownContentTypeKeys: ['fake_pulse_a', 'fake_pulse_b'],
+  contentItemSchemas: [schemaA, schemaB],
+};
+module.exports = { proPlugins: [fakePlugin] };
+`;
+
+// ---------------------------------------------------------------------------
+// Page content fixtures
+// ---------------------------------------------------------------------------
+
+const MINIMAL_PAGE_OSS = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: text_block
+      label: intro
+      textBlocks: []
+`;
+
+const PAGE_WITH_FAKE_PULSE = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: fake_pulse
+      label: widget-a
+`;
+
+const PAGE_WITH_PULSE_A = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: fake_pulse_a
+      label: widget-a
+`;
+
+const PAGE_WITH_PULSE_B = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: fake_pulse_b
+      label: widget-b
+`;
+
+const PAGE_WITH_PULSE_A_AND_B = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: fake_pulse_a
+      label: widget-a
+    - type: fake_pulse_b
+      label: widget-b
+`;
+
+const PAGE_WITH_BOGUS_TYPE = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: truly_bogus_widget
+      label: oops
+`;
+
+// ---------------------------------------------------------------------------
+// Test A — single [INFO] summary across 3 pages using the same type
+// ---------------------------------------------------------------------------
+
+describe('swp-3r93: dedup plugin-type warnings', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Test A: 3 pages using fake_pulse → exactly ONE [INFO] summary, zero old-format [WARN] lines', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_SINGLE);
+    writePageYaml(projectRoot, PAGE_WITH_FAKE_PULSE);
+    writePageYaml(projectRoot, PAGE_WITH_FAKE_PULSE, 'page-two');
+    writePageYaml(projectRoot, PAGE_WITH_FAKE_PULSE, 'page-three');
+
+    const logLines: string[] = [];
+    const warnLines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => logLines.push(String(args[0])));
+    vi.spyOn(console, 'warn').mockImplementation((...args) => warnLines.push(String(args[0])));
+
+    await runPrebuild({ projectRoot });
+
+    // Old per-page format must be completely gone
+    const oldFormatWarn = warnLines.filter((m) => m.includes('plugin-declared type(s)'));
+    expect(oldFormatWarn).toHaveLength(0);
+
+    // Exactly ONE new [INFO] summary line
+    const summaryLines = logLines.filter((m) => m.includes('[INFO] Plugin-declared content types'));
+    expect(summaryLines).toHaveLength(1);
+
+    // Summary reports 3 pages
+    expect(summaryLines[0]).toContain('3 page(s)');
+
+    // fake_pulse appears in the summary
+    expect(summaryLines[0]).toContain('fake_pulse');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test B — zero pages use plugin types → NO summary
+  // -------------------------------------------------------------------------
+
+  it('Test B: no pages use plugin types → no [INFO] Plugin-declared summary at all', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_SINGLE);
+    // Pages only use core OSS types
+    writePageYaml(projectRoot, MINIMAL_PAGE_OSS);
+    writePageYaml(projectRoot, MINIMAL_PAGE_OSS, 'about');
+
+    const logLines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => logLines.push(String(args[0])));
+
+    await runPrebuild({ projectRoot });
+
+    const summaryLines = logLines.filter((m) => m.includes('[INFO] Plugin-declared content types'));
+    expect(summaryLines).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test C — regression guard: genuine validation errors still fire per-page
+  // -------------------------------------------------------------------------
+
+  it('Test C (regression): truly_bogus_widget with unknownContentTypes warn → per-page [WARN] still fires', async () => {
+    const projectRoot = makeTempProject();
+    // No plugin installed, so truly_bogus_widget is entirely unknown
+    writePageYaml(projectRoot, PAGE_WITH_BOGUS_TYPE, 'bad-page-one');
+    writePageYaml(projectRoot, PAGE_WITH_BOGUS_TYPE, 'bad-page-two');
+
+    const warnLines: string[] = [];
+    vi.spyOn(console, 'warn').mockImplementation((...args) => warnLines.push(String(args[0])));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runPrebuild({ projectRoot, unknownContentTypes: 'warn' });
+
+    // Both bad pages must emit a [WARN] (per-page validation errors are NOT deduped)
+    const validationWarns = warnLines.filter(
+      (m) => m.includes('[WARN]') && m.includes('Invalid content')
+    );
+    expect(validationWarns).toHaveLength(2);
+  });
+
+  it('Test C2: one page with truly_bogus_widget → exactly one [WARN] Invalid content', async () => {
+    const projectRoot = makeTempProject();
+    writePageYaml(projectRoot, PAGE_WITH_BOGUS_TYPE);
+
+    const warnLines: string[] = [];
+    vi.spyOn(console, 'warn').mockImplementation((...args) => warnLines.push(String(args[0])));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runPrebuild({ projectRoot, unknownContentTypes: 'warn' });
+
+    const validationWarns = warnLines.filter(
+      (m) => m.includes('[WARN]') && m.includes('Invalid content')
+    );
+    expect(validationWarns).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test D — multi-page, multi-type: correct page count and type list
+  // -------------------------------------------------------------------------
+
+  it('Test D: 2 pages use fake_pulse_a, 3 use fake_pulse_b, 1 uses both → summary has 5 unique pages + both types', async () => {
+    const projectRoot = makeTempProject();
+    installFakePackage(projectRoot, CANONICAL_PRO_BUNDLE, FAKE_PRO_BUNDLE_DUAL);
+
+    // page-a1 and page-a2 → fake_pulse_a only
+    writePageYaml(projectRoot, PAGE_WITH_PULSE_A, 'page-a1');
+    writePageYaml(projectRoot, PAGE_WITH_PULSE_A, 'page-a2');
+    // page-b1, page-b2 → fake_pulse_b only
+    writePageYaml(projectRoot, PAGE_WITH_PULSE_B, 'page-b1');
+    writePageYaml(projectRoot, PAGE_WITH_PULSE_B, 'page-b2');
+    // page-both → uses both types (counted as 1 unique page)
+    writePageYaml(projectRoot, PAGE_WITH_PULSE_A_AND_B, 'page-both');
+    // page-oss → no plugin types (should not appear in count)
+    writePageYaml(projectRoot, MINIMAL_PAGE_OSS, 'page-oss');
+
+    const logLines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => logLines.push(String(args[0])));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await runPrebuild({ projectRoot });
+
+    const summaryLines = logLines.filter((m) => m.includes('[INFO] Plugin-declared content types'));
+    expect(summaryLines).toHaveLength(1);
+
+    const summary = summaryLines[0];
+    // 5 unique pages: a1, a2, b1, b2, both
+    expect(summary).toContain('5 page(s)');
+    // Both types present
+    expect(summary).toContain('fake_pulse_a');
+    expect(summary).toContain('fake_pulse_b');
+    // Declaring plugin named correctly
+    expect(summary).toContain('fake-multi-plugin');
+  });
+});

--- a/packages/build-scripts/test/prebuild-unknown-content-types-config.test.ts
+++ b/packages/build-scripts/test/prebuild-unknown-content-types-config.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for `prebuild.unknownContentTypes` yml config wiring (#529 leftover).
+ *
+ * Verifies that the `prebuild.unknownContentTypes` field in `stackwright.yml`
+ * controls validation behaviour, and that an explicit `runPrebuild` option
+ * always wins over the yml value (precedence: explicit > yml > default 'error').
+ *
+ * All tests use real temp directories — no mocks on fs/yaml parsing.
+ * See CONTRIBUTING.md "Testing Philosophy" for why.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { runPrebuild } from '../src/prebuild';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeTempProject(siteYaml: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sw-uct-config-test-'));
+  fs.writeFileSync(path.join(dir, 'stackwright.yml'), siteYaml);
+  fs.mkdirSync(path.join(dir, 'pages'), { recursive: true });
+  return dir;
+}
+
+function writePageYaml(projectRoot: string, yaml: string, slug?: string): void {
+  const dir = slug ? path.join(projectRoot, 'pages', slug) : path.join(projectRoot, 'pages');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'content.yml'), yaml);
+}
+
+// ---------------------------------------------------------------------------
+// Site YAML fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_SITE_YAML = `\
+title: Test Site
+navigation: []
+appBar:
+  titleText: Test Site
+`;
+
+const SITE_YAML_UCT_WARN = `\
+title: Test Site
+navigation: []
+appBar:
+  titleText: Test Site
+prebuild:
+  unknownContentTypes: warn
+`;
+
+const SITE_YAML_UCT_IGNORE = `\
+title: Test Site
+navigation: []
+appBar:
+  titleText: Test Site
+prebuild:
+  unknownContentTypes: ignore
+`;
+
+// ---------------------------------------------------------------------------
+// Page content fixtures
+// ---------------------------------------------------------------------------
+
+const PAGE_WITH_BOGUS_TYPE = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: totally_bogus_type_xyz
+      label: oops
+`;
+
+const MINIMAL_PAGE_OSS = `\
+meta:
+  title: Hello
+content:
+  content_items:
+    - type: text_block
+      label: intro
+      textBlocks: []
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('prebuild.unknownContentTypes yml config wiring', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test E — yml says 'warn', no explicit option → does NOT throw, emits [WARN]
+  // -------------------------------------------------------------------------
+
+  it('Test E: yml unknownContentTypes: warn → prebuild does NOT throw, emits [WARN]', async () => {
+    const projectRoot = makeTempProject(SITE_YAML_UCT_WARN);
+    writePageYaml(projectRoot, PAGE_WITH_BOGUS_TYPE);
+
+    const warnLines: string[] = [];
+    vi.spyOn(console, 'warn').mockImplementation((...args) => warnLines.push(String(args[0])));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // No explicit unknownContentTypes passed — should read from yml
+    await expect(runPrebuild({ projectRoot, plugins: [] })).resolves.not.toThrow();
+
+    const validationWarns = warnLines.filter(
+      (m) => m.includes('[WARN]') && m.includes('Invalid content')
+    );
+    expect(validationWarns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test F — yml says 'warn' but explicit 'error' → throws (explicit wins)
+  // -------------------------------------------------------------------------
+
+  it('Test F: yml says warn but runPrebuild({ unknownContentTypes: error }) → throws', async () => {
+    const projectRoot = makeTempProject(SITE_YAML_UCT_WARN);
+    writePageYaml(projectRoot, PAGE_WITH_BOGUS_TYPE);
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // Explicit 'error' must win over yml 'warn'
+    await expect(
+      runPrebuild({ projectRoot, plugins: [], unknownContentTypes: 'error' })
+    ).rejects.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test G — yml says 'ignore' → no warn, no throw, page compiles
+  // -------------------------------------------------------------------------
+
+  it('Test G: yml unknownContentTypes: ignore → bogus type silently ignored, output written', async () => {
+    const projectRoot = makeTempProject(SITE_YAML_UCT_IGNORE);
+    writePageYaml(projectRoot, PAGE_WITH_BOGUS_TYPE);
+
+    const warnLines: string[] = [];
+    vi.spyOn(console, 'warn').mockImplementation((...args) => warnLines.push(String(args[0])));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(runPrebuild({ projectRoot, plugins: [] })).resolves.not.toThrow();
+
+    const validationWarns = warnLines.filter(
+      (m) => m.includes('[WARN]') && m.includes('Invalid content')
+    );
+    expect(validationWarns).toHaveLength(0);
+
+    // Page JSON must still be written
+    const rootJson = path.join(projectRoot, 'public', 'stackwright-content', '_root.json');
+    expect(fs.existsSync(rootJson)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test H — no prebuild block in yml → falls back to 'error' default
+  // -------------------------------------------------------------------------
+
+  it('Test H: yml has no prebuild block → defaults to error, throws on bogus type', async () => {
+    const projectRoot = makeTempProject(BASE_SITE_YAML);
+    writePageYaml(projectRoot, PAGE_WITH_BOGUS_TYPE);
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // No explicit option, no yml config → should throw (default is 'error')
+    await expect(runPrebuild({ projectRoot, plugins: [] })).rejects.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test I — sanity: yml warn + valid page → no warning, no throw
+  // -------------------------------------------------------------------------
+
+  it('Test I: yml warn + valid OSS page → clean compile', async () => {
+    const projectRoot = makeTempProject(SITE_YAML_UCT_WARN);
+    writePageYaml(projectRoot, MINIMAL_PAGE_OSS);
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(runPrebuild({ projectRoot, plugins: [] })).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of closing the #529 plugin-discovery loop. Two changes bundled in one PR (same file cluster).

### Change 1 — swp-3r93: dedup plugin-declared content type warnings

**Before:** every page using a plugin-declared type emitted its own `[WARN]` line. DHL's 22 pages × pulse types = 22 identical noisy warnings.

**After:** a single `[INFO]` summary fires after all pages are processed:

```
  [INFO] Plugin-declared content types in use across 3 page(s):
    - fake_pulse (from: fake-pulse-plugin)
  App code must call registerContentType() at runtime for each of these types.
  (Build-time schema validation succeeded via plugin discovery — this is a runtime reminder.)
```

Key improvements:
- Downgraded from `console.warn` to `console.log` with `[INFO]` prefix — not an error condition
- Explicitly distinguishes build-time validation (already passed via #529) from runtime component registration
- Zero spam: accumulate across all pages, emit once

Genuine validation errors (`[WARN] Invalid content ...`) are completely unaffected — still per-page.

### Change 2 — #529 leftover: wire `prebuild.unknownContentTypes` from yml

The `prebuild.unknownContentTypes` field was added to the schema in #529 but never wired into the pipeline. Now it works:

```yaml
# stackwright.yml
prebuild:
  unknownContentTypes: warn   # or 'error' (default) or 'ignore'
```

**Precedence:** explicit `runPrebuild({ unknownContentTypes })` > yml value > `'error'` default.

Implementation (Option C from the design doc): `peekYmlUCT()` helper in `compileAll` peeks at the yml before any sink runs and fills in `ctx.unknownContentTypes` when the caller didn't pass an explicit value. `createCompileContext` now returns `undefined` (not `'error'`) for the default case so the explicit-vs-default distinction is preserved.

## Files changed

- `packages/build-scripts/src/compile/pages.ts` — dedup logic (Change 1)
- `packages/build-scripts/src/compile/context.ts` — default `'error'` → `undefined` (Change 2)
- `packages/build-scripts/src/compile/index.ts` — `peekYmlUCT` helper + UCT resolution in `compileAll` (Change 2)
- `packages/build-scripts/test/plugin-hooks.test.ts` — updated Gap 1 tests for new `[INFO]` format
- `packages/build-scripts/test/prebuild-plugin-type-warnings.test.ts` — **NEW** (5 tests, Change 1)
- `packages/build-scripts/test/prebuild-unknown-content-types-config.test.ts` — **NEW** (5 tests, Change 2)

## Test results

```
Test Files  19 passed (19)
Tests       288 passed (288)    # was 278 before this PR (+10 new integration tests)
```

## Format/lint

- All format failures are pre-existing on `dev` (`collections.ts`, `fonts.ts`, `path-utils.ts`, `site.ts`, `image-optimizer.ts`, `image-optimizer.test.ts`, `prebuild-images.test.ts`, `mcp/register-subpath.test.ts`)
- All 6 lint warnings are pre-existing
- My changed files pass format check

## Smoke test

Vanilla OSS empty-folder run: clean. `_root.json`, `_site.json`, `_theme.json`, icon manifest, image manifest all written. No regressions.

---

Beads: swp-3r93 (dedup) + PR #529 leftover (yml threading)