### PR TITLE
chore: format 8 files pending Prettier (unblocks sweep release)

### DIFF
--- a/packages/build-scripts/src/compile/collections.ts
+++ b/packages/build-scripts/src/compile/collections.ts
@@ -2,7 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 import { collectionConfigSchema } from '@stackwright/types';
-import type { CollectionConfig, EntryPageConfig, PageContent, TypographyVariant } from '@stackwright/types';
+import type {
+  CollectionConfig,
+  EntryPageConfig,
+  PageContent,
+  TypographyVariant,
+} from '@stackwright/types';
 import { copyIfNewer, rewritePaths, isColocatablePath } from './path-utils';
 import type { CompileContext } from './context';
 
@@ -250,7 +255,9 @@ export function generateEntryPages(
     const outFile = path.join(outDir, `${slug}.json`);
     const resolvedOutFile = path.resolve(outFile);
     if (!resolvedOutFile.startsWith(resolvedOutDir + path.sep)) {
-      console.warn(`  WARNING: Skipping entry "${slug}" -- resolved path escapes output directory.`);
+      console.warn(
+        `  WARNING: Skipping entry "${slug}" -- resolved path escapes output directory.`
+      );
       continue;
     }
 
@@ -320,9 +327,7 @@ function processCollectionEntryContent(
 /**
  * Synchronous: all operations are YAML parsing and file writes.
  */
-export function compileFileCollections(
-  ctx: CompileContext
-): FileCollectionsResult {
+export function compileFileCollections(ctx: CompileContext): FileCollectionsResult {
   const { projectRoot, contentOutDir, imagesDir } = ctx;
   const contentDir = path.join(projectRoot, 'content');
 

--- a/packages/build-scripts/src/compile/fonts.ts
+++ b/packages/build-scripts/src/compile/fonts.ts
@@ -44,9 +44,7 @@ export function extractGoogleFontNames(fontFamily: string): string[] {
  */
 export function generateGoogleFontsUrl(fonts: string[]): string {
   if (!fonts || fonts.length === 0) return '';
-  const familyParams = fonts
-    .map((font) => `family=${font.replace(/ /g, '+')}:wght@400`)
-    .join('&');
+  const familyParams = fonts.map((font) => `family=${font.replace(/ /g, '+')}:wght@400`).join('&');
   return `https://fonts.googleapis.com/css2?${familyParams}&display=swap`;
 }
 
@@ -214,9 +212,10 @@ export async function compileFonts(ctx: CompileContext): Promise<void> {
   const themeData = fs.existsSync(themeJsonPath)
     ? (JSON.parse(fs.readFileSync(themeJsonPath, 'utf8')) as Record<string, unknown>)
     : {};
-  const configForFontNames = Object.keys(themeData).length > 0
-    ? { ...configWithEnvResolved, ...themeData }
-    : configWithEnvResolved;
+  const configForFontNames =
+    Object.keys(themeData).length > 0
+      ? { ...configWithEnvResolved, ...themeData }
+      : configWithEnvResolved;
 
   if (fontStrategy === 'bundle') {
     const allFonts = getAllGoogleFontNames(configForFontNames);

--- a/packages/build-scripts/src/compile/path-utils.ts
+++ b/packages/build-scripts/src/compile/path-utils.ts
@@ -25,14 +25,7 @@ export const IMAGE_EXTENSIONS = new Set([
 ]);
 
 // Keep in sync with VIDEO_EXTENSIONS_ARRAY exported from @stackwright/types
-export const VIDEO_EXTENSIONS = new Set([
-  '.mp4',
-  '.webm',
-  '.ogg',
-  '.mov',
-  '.avi',
-  '.mkv',
-]);
+export const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.ogg', '.mov', '.avi', '.mkv']);
 
 // ---------------------------------------------------------------------------
 // Predicates

--- a/packages/build-scripts/src/compile/site.ts
+++ b/packages/build-scripts/src/compile/site.ts
@@ -69,10 +69,7 @@ function auditIntegrationAuthSecrets(config: unknown): void {
 /**
  * Validate integration configs against plugin schemas.
  */
-function validateIntegrationConfigs(
-  integrations: unknown[],
-  plugins: PrebuildPlugin[]
-): void {
+function validateIntegrationConfigs(integrations: unknown[], plugins: PrebuildPlugin[]): void {
   for (const integration of integrations) {
     if (!integration || typeof integration !== 'object') continue;
     const item = integration as Record<string, unknown>;
@@ -242,4 +239,3 @@ export function compileSite(ctx: CompileContext): SiteCompileResult {
 
   return { processedConfig: configWithEnvResolved };
 }
-

--- a/packages/build-scripts/src/image-optimizer.ts
+++ b/packages/build-scripts/src/image-optimizer.ts
@@ -88,7 +88,7 @@ async function getSharp(): Promise<typeof sharpType> {
   if (!sharpFn) {
     try {
       const mod = await import('sharp');
-       
+
       sharpFn = ((mod as any).default ?? mod) as typeof sharpType;
     } catch {
       throw new Error(

--- a/packages/build-scripts/test/image-optimizer.test.ts
+++ b/packages/build-scripts/test/image-optimizer.test.ts
@@ -18,7 +18,7 @@ import type { ImageOptimizationConfig } from '@stackwright/types';
 // ESM environment where `import('sharp')` exposes { default: fn, ... }.
 async function getSharp() {
   const mod = await import('sharp');
-   
+
   return ((mod as any).default ?? mod) as typeof import('sharp');
 }
 

--- a/packages/build-scripts/test/prebuild-images.test.ts
+++ b/packages/build-scripts/test/prebuild-images.test.ts
@@ -14,7 +14,7 @@ import { runPrebuild } from '../src/prebuild';
  */
 async function getSharp() {
   const mod = await import('sharp');
-   
+
   return ((mod as any).default ?? mod) as typeof import('sharp');
 }
 

--- a/packages/mcp/test/register-subpath.test.ts
+++ b/packages/mcp/test/register-subpath.test.ts
@@ -115,7 +115,7 @@ describe('register subpath — tool surface integration', () => {
     registerA11yTools(server);
 
     // Introspect via the internal registry (plain object, keys = tool names).
-     
+
     registeredToolNames = Object.keys((server as any)._registeredTools);
   });
 


### PR DESCRIPTION
## What

Runs Prettier on 8 files that were introduced/modified in prior PRs without a format pass. Cleanup of the exact set drawer 1306 flagged as a required follow-up.

## Why now

Blocks the sweep dev to main release currently sitting on `release/sweep-2026-07-12`. Rather than format on the release branch (which would violate the drawer 1093 rule about isolating format changes from release-critical branches), we do the cleanup here first, then rebase the release branch on the updated dev.

## Files touched

Pure Prettier output on:
- `packages/build-scripts/src/compile/collections.ts`
- `packages/build-scripts/src/compile/fonts.ts`
- `packages/build-scripts/src/compile/path-utils.ts`
- `packages/build-scripts/src/compile/site.ts`
- `packages/build-scripts/src/image-optimizer.ts`
- `packages/build-scripts/test/image-optimizer.test.ts`
- `packages/build-scripts/test/prebuild-images.test.ts`
- `packages/mcp/test/register-subpath.test.ts`

## Verification

- `pnpm build`: pass
- `pnpm test`: 1,471 tests pass, 0 failures (note: count is higher than the 1,031 noted in pre-release verification — that prior count appears to have been taken before additional test files landed on dev; the count is consistent across dev and this branch, confirming zero semantic change)
- `pnpm lint`: 0 errors, 6 warnings (same pre-existing warnings)
- `pnpm format:check`: **pass** (was failing on these 8 files pre-change)

Zero semantic changes. Diff is pure whitespace: 8 files, 21 insertions, 28 deletions.

## After merge

Sweep release resumes: reset `release/sweep-2026-07-12` onto the new dev, re-run gates, open PR to main.
